### PR TITLE
Add Polymarket Alpha Bot to AI Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Perfect for traders, researchers, and quants who want a unified prediction-marke
 - [Agok](https://agok.ai/?utm_source=polymark.et) — No-code AI agent platform enabling users to build, deploy, and share intelligent agents with natural language commands, featuring Polymarket integration, blockchain tools, and enterprise-ready compliance features.
 - [PolyOracle](https://app.polyoracle.com/?utm_source=polymark.et) — An AI-powered system that uses multiple LLMs (large language models) to analyze Polymarket’s most active markets. Instead of one brain making decisions, it’s a collective of AIs reaching consensus.
 - [Predly](https://predly.ai/?utm_source=polymark.et) — AI-powered prediction market analytics platform that identifies profitable opportunities on Polymarket and Kalshi by detecting mispricings between market prices and AI-calculated probabilities with 89% alert accuracy.
+- [Polymarket Alpha Bot](https://github.com/chainstacklabs/polymarket-alpha-bot) — Open-source alpha detection platform using LLM-powered analysis to discover hedging opportunities between correlated Polymarket markets, with web dashboard for position tracking.
 
 ## 🧩 APIs
 


### PR DESCRIPTION
## Summary

Adding [Polymarket Alpha Bot](https://github.com/chainstacklabs/polymarket-alpha-bot) to the 🧠 AI Agents section.

**Polymarket Alpha Bot** is an open-source alpha detection platform using LLM-powered analysis to discover hedging opportunities between correlated Polymarket markets, with a web dashboard for position tracking.

### Features
- Fetches multi-outcome markets from Polymarket
- LLM-powered relationship detection between market groups
- Identifies position pairs that hedge each other (covering portfolios)
- Web dashboard for position tracking and execution
- FastAPI backend + React frontend

### Links
- GitHub: https://github.com/chainstacklabs/polymarket-alpha-bot