### PR TITLE
Add SettleRisk — resolution risk scoring API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,274 +1,63 @@
-# Awesome Prediction Market Tools
+# Awesome Prediction Markets
 
-[![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
+Overview of of various Prediciton Markets along with selected reading, threads, and various code repositories
 
-> The most complete, community-maintained directory of prediction market tools — analytics platforms, trading bots, dashboards, APIs, data feeds, alert systems, educational resources, and more.  
-> Covering Polymarket, Kalshi, Manifold, Hyperliquid, and the wider forecasting ecosystem.
+## Markets 
+- [Polymarket](https://polymarket.com/ma) 
+    - Polygon, USDC
+- [Manifold](manifold.markets) 
+    - Offchain and no real money
+- [Kalshi](https://kalshi.com/) 
+    - CFTC Regulated so via bank
+- [Metaculus](https://www.metaculus.com/home/)
+- [Predictit](https://www.predictit.org/)
+- [Insight Predictions](https://insightprediction.com/)
+- [Hedgehog](https://hedgehog.markets/)
+    - on solana, has a nice mobile app
+- [Aver](aver.exchange)
+- [Pascal](https://www.pascal.fi/) 
+    - Solana, USDC (but devnet)
+- [Futuur](https://futuur.com/)
+- [Infer](https://www.infer-pub.com/)
+- [smarkets](https://smarkets.com)
+- [Pulse Markets](https://www.pulsemarkets.org/)
+    - On near uses flux protocol for oracles
+- [Polkamarkets](https://www.polkamarkets.com/)
+    - on polkadot
+- [Omen](https://omen.eth.limo/)
+    - no longer active but here is an [ipfs link](https://bafybeidaqe523nwbyvhvd74jx57eqge2ezkz2lvfofrkczfs5df5jxq33m.ipfs.dweb.link/#/liquidity)
 
-Pull requests welcome — add your tool or improve the list!
+## Selected Reading
+- [Prediction Market FAQ](https://astralcodexten.substack.com/p/prediction-market-faq)
+- [Information Markets, Decision Markets, Attention Markets, Action Markets](https://astralcodexten.substack.com/p/information-markets-decision-markets)
+- [Play Money and Reputation Systems](https://astralcodexten.substack.com/p/play-money-and-reputation-systems?s=r)
+- [The Passage Of Polymarket](https://astralcodexten.substack.com/p/the-passage-of-polymarket?s=r)
+- [ACX Grant Results](https://astralcodexten.substack.com/p/acx-grants-results?s=r)
+- [Mantic Monday: Dogs in Wizard hats](https://astralcodexten.substack.com/p/mantic-monday-dogs-in-wizard-hats)
+- [Market Mechanics](https://manifoldmarkets.substack.com/p/above-the-fold-market-mechanics?s=r)
+- [Borrow away!](https://manifoldmarkets.substack.com/p/above-the-fold-borrow-away?s=r)
+- [Invasion Edition](https://manifoldmarkets.substack.com/p/above-the-fold-invasion-edition?s=r)
+- [Above the Fold](https://manifoldmarkets.substack.com/)
+- [The Making of a Top Forecaster](https://www.infer-pub.com/blog/top-forecaster-techniques)
+- [Amplyifing Research via Forecaster Part 1](https://www.lesswrong.com/posts/cLtdcxu9E4noRSons) and [Part 2](https://www.lesswrong.com/posts/FeE9nR7RPZrLtsYzD/part-2-amplifying-generalist-research-via-forecasting)
+- [Incentive problems with forecasting](https://www.lesswrong.com/posts/tyNrj2wwHSnb4tiMk/incentive-problems-with-current-forecasting-competitions)
+- [Maximum Truth: Betting on the Elections](https://maximumtruth.substack.com/p/deep-dive-on-predicting-elections)
 
----
+## Cool Websites
+- [BaseRateTimes](https://www.baseratetimes.com/) - News through the lens of various prediction markets
+- [MetaForecast](https://metaforecast.org/) - Aggregator
+- [loki.red Polymarket Stats](https://www.loki.red/polymarket/)
+- [Good Judgement](https://www.gjopen.com/)
+- [SettleRisk](https://settlerisk.com) - Resolution risk scoring, dispute pricing, and settlement delay API for prediction markets
 
-## ⭐ Featured: Oddpool
+## Respositories
+- [Polymarket Info](https://github.com/PolyTrader/polymarket-info)
+- [Polymarket Stats](https://github.com/bodino/PolymarketStats)
+- [Polymarket Trader](https://github.com/elielieli909/polymarket-marketmaking)
+- [Manifold Market Maker](https://github.com/manifoldmarkets/market-maker)
+- [Manifold Market Maker that uses OpenAI to answer questions](https://github.com/neverix/nevbot)
 
-**[Oddpool](https://www.oddpool.com)** — _The Bloomberg for prediction markets._
-
-Oddpool aggregates live cross-venue odds, spreads, arbitrage opportunities, historical price data, market depth, economic indicators, and analytics across Polymarket, Kalshi, CME, and more.  
-Perfect for traders, researchers, and quants who want a unified prediction-market data layer.
-
-👉 **Check out the live dashboards:**  
-**https://www.oddpool.com**
-
----
-
-## Contents
-
-- [🧠 AI Agents](#ai-agents)
-- [🧩 APIs](#apis)
-- [🔹 Aggregator](#aggregator)
-- [🔔 Alerts](#alerts)
-- [📊 Analytics Tools](#analytics-tools)
-- [🔹 Arbitrage tools](#arbitrage-tools)
-- [📈 Dashboards](#dashboards)
-- [📡 Data](#data)
-- [💸 DeFi](#defi)
-- [📚 Educational Resources](#educational-resources)
-- [🔹 Extensions](#extensions)
-- [🔹 Funds](#funds)
-- [🏗️ Infrastructure](#infrastructure)
-- [📰 News](#news)
-- [🏛️ Official](#official)
-- [🟪 Others](#others)
-- [🔹 Parlays](#parlays)
-- [🔹 Portfolio Tracking](#portfolio-tracking)
-- [🤖 Trading Bots](#trading-bots)
-
-## 🧠 AI Agents
-
-- [Alphascope](https://www.alphascope.app/?utm_source=polymark.et) — AI-driven market intelligence engine for prediction markets, delivering real-time signals, research, and probability shifts.
-- [Polyfactual](https://www.polyfactual.com/?utm_source=polymark.et) — AI-powered platform blending prediction markets and social narratives to track and trade on event truthfulness.
-- [Polytrader](https://www.polytrader.ai/?utm_source=polymark.et) — AI-Powered Prediction Market Trading – Polytrader enhances Polymarket trading by integrating - AI-driven analysis, automated trading strategies, and social sentiment tracking.
-- [Sportstensor](https://www.sportstensor.com/?utm_source=polymark.et) — Decentralized AI-powered sports prediction platform leveraging collective intelligence and ensemble modeling to uncover persistent market patterns.
-- [BillyBets](https://billybets.ai/?utm_source=polymark.et) — Autonomous AI sports betting agent that operates 24/7, analyzing real-time data from SportsTensor and top bettors to provide insights and autonomously place bets on blockchain sportsbooks.
-- [Fraction AI](https://fractionai.xyz/?utm_source=polymark.et) — First decentralized auto-training platform for AI agents that compete, learn, and evolve through continuous reinforcement learning in specialized environments called Spaces.
-- [Bankr](https://bankr.bot/?utm_source=polymark.et) — The leading crypto AI agent with Polymarket integration, plus your new AI-assisted crypto wallet on X + private terminal.
-- [PredictionSwap](https://predictionswap.com?utm_source=polymark.et) — AI-powered prediction market aggregator providing real-time analysis, cross-platform odds, and actionable insights for smarter forecasting.
-- [Pigeon](https://pigeon.trade/?utm_source=polymark.et) — AI-powered multi-platform trading terminal enabling cross-market trading of crypto, stocks, perps, predictions, and memecoins through chat interfaces across 10+ platforms including Telegram, Discord, and WhatsApp.
-- [Elastics](https://www.elastics.ai/?utm_source=polymark.et) — AI-native, institutional operating system for automated, data-driven trading with integrated portfolio and risk management.
-- [Forcazt](https://forcazt.xyz/?utm_source=polymark.et) — AI-powered prediction market analytics and aggregator for discovering high-alpha markets, arbitrage, and data-driven edge.
-- [Polyprophet](https://polyprophet.com?utm_source=polymark.et) — Chrome extension providing AI-powered real-time predictions for Polymarket using multiple leading AI models and proprietary historical data analysis.
-- [Polybro](https://www.polybro.app?utm_source=polymark.et) — Autonomous AI-powered Polymarket trading agent that conducts structured research across academic papers, news, and live data to generate evidence-based predictions and trading signals.
-- [Polymarket Tips](https://polymarket.tips?utm_source=polymark.et) — AI-powered sentiment analysis platform providing real-time social media intelligence and trading recommendations for Polymarket prediction markets.
-- [Inside Edge](https://inside.fyi/?utm_source=polymark.et) — AI-powered prediction market analysis platform that identifies market inefficiencies on Polymarket to help users find profitable trading opportunities with quantified edge percentages.
-- [Jatevo](https://jatevo.ai/agents/prediction-market?utm_source=polymark.et) — Deep research platform powered by 6-agent AI pipeline for prediction market analysis with Polymarket API integration.
-- [PolyMaster](https://polymaster.io?utm_source=polymark.et) — AI-powered Polymarket analysis platform with whale tracking, predictive modeling, and real-time market intelligence.
-- [PolyTale](https://polytale.live/?utm_source=polymark.et) — AI-powered Polymarket intelligence platform that operates as the first prediction market research AI agent on Twitter, providing real-time market insights and whale tracking.
-- [Poly Cafe](https://polycafe.life/?utm_source=polymark.et) — Next-generation SocialFi platform featuring persistent 3D AI agents called "Quants" that autonomously discover, analyze, and trade on prediction markets in a 24/7 virtual world, combining AI-powered market analysis with a gamified intel marketplace where users can monetize insights through customizable storefronts.
-- [PolyPulse](https://www.polypulse.tech/?utm_source=polymark.et) — Free Chrome extension providing AI-powered news analysis for Polymarket traders through automatic market detection, real-time insights from Perplexity AI, and secure local data storage with 100% privacy-focused design and community support.
-- [Semantic 42](https://42.semanticlayer.io?utm_source=polymark.et) — Autonomous AI agent trading platform enabling specialized agents to research, analyze, and execute verified trades on Polymarket directly from Base blockchain using x402 protocol and AGI Solver engine, featuring real-time activity monitoring, inter-agent fund transfers, and transparent performance tracking with $50,000 initial funding.
-- [Fere AI](https://fereai.xyz?utm_source=polymark.et) — Multi-agent AI crypto assistant combining cross-chain capabilities, Polymarket prediction market discovery, memecoin analysis, and yield farming in one autonomous platform featuring real-time market sentiment analysis, whale tracking, and specialized agents for research, execution, and communication.​​
-- [PolyRadar](https://www.polyradar.io/?utm_source=polymark.et) — AI-powered prediction analysis platform leveraging multiple independent AI models to provide comprehensive insights for Polymarket events, featuring real-time analysis, timeline visualization, confidence scoring, and source transparency with 50+ data sources per event analysis.
-- [Astron](https://www.astron.markets/?utm_source=polymark.et) — AI agent protocol building intelligent, autonomous agents for prediction markets with flagship product Raven 1.0 achieving up to 98% short-term forecasting accuracy, featuring tokenized strategies, automated execution, and real-time sentiment analysis across sports betting and prediction market platforms.
-- [Polyseer](https://www.polyseer.xyz/?utm_source=polymark.et) — Open-source AI research platform that provides systematic evidence-based analysis for Polymarket and Kalshi prediction markets using multi-agent architecture, Bayesian probability aggregation, and real-time data sources to generate comprehensive reports with mathematical confidence scores.
-- [UnifAI](https://unifai.network?utm_source=polymark.et) — AI-native infrastructure platform enabling autonomous agents to automate, discover, and optimize DeFi strategies across protocols—serving users and developers with adaptive, secure, and modular design.
-- [TatorTrader](https://tatortrader.quickintel.io/?utm_source=polymark.et) — All-in-one conversational crypto platform enabling seamless Polymarket, Myriad, and Limitless betting through conversational interfaces across social media timelines, messaging apps, and mobile platforms.
-- [Agok](https://agok.ai/?utm_source=polymark.et) — No-code AI agent platform enabling users to build, deploy, and share intelligent agents with natural language commands, featuring Polymarket integration, blockchain tools, and enterprise-ready compliance features.
-- [PolyOracle](https://app.polyoracle.com/?utm_source=polymark.et) — An AI-powered system that uses multiple LLMs (large language models) to analyze Polymarket’s most active markets. Instead of one brain making decisions, it’s a collective of AIs reaching consensus.
-- [Predly](https://predly.ai/?utm_source=polymark.et) — AI-powered prediction market analytics platform that identifies profitable opportunities on Polymarket and Kalshi by detecting mispricings between market prices and AI-calculated probabilities with 89% alert accuracy.
-- [PolyClaw](https://github.com/chainstacklabs/polyclaw) — OpenClaw skill for Polymarket trading with order execution and LLM-powered hedge discovery via contrapositive logic (arbitrage).
-
-## 🧩 APIs
-
-- [Adjacent News](https://adj.news/?utm_source=polymark.et) — Forward-looking news platform delivering prediction market-driven, contextual, and breaking news with advanced data and trading APIs.
-- [ClickHouse](https://crypto.clickhouse.com/?utm_source=polymark.et) — Open-source, columnar OLAP database delivering blazing-fast analytics for large-scale, real-time data across multiple industries.
-- [Dome](https://domeapi.io?utm_source=polymark.et) — Developer infrastructure platform providing unified APIs and SDKs for accessing real-time and historical prediction market data across multiple platforms.
-- [PolyRouter](https://polyrouter.io?utm_source=polymark.et) — Unified API service that provides normalized prediction market data from Kalshi, Polymarket, Limitless, and other platforms through a single API key and standardized interface.
-- [PMXT](https://github.com/qoery-com/pmxt) - An open-source API for accessing prediction market data across multiple exchanges.
-
-## 🔹 Aggregator
-
-- [Verso](https://www.verso.trading/?utm_source=polymark.et) — Professional-grade prediction market terminal that provides real-time market data, analytics, and news intelligence for Polymarket and Kalshi traders in a Bloomberg-style institutional interface.
-- [Matchr](https://matchr.xyz?utm_source=polymark.et) — Universal prediction market aggregator that searches 1500+ markets across platforms like Polymarket and Kalshi to find the best prices and execute trades with smart routing and automated yield strategies.
-- [Firefly](https://firefly.social?utm_source=polymark.et) — Web3 everything app combining social media aggregation, prediction market betting, and onchain activity tracking across multiple platforms and networks.
-- [trade.fun](https://trade.fun/?utm_source=polymark.et) — Comprehensive multi-asset trading platform integrating Polymarket prediction markets, Solana memecoins, perpetuals with up to 40x leverage, and yield farming in one customizable interface, featuring zero gas fees, and MEV protection.
-- [TradeFox](https://thetradefox.com?utm_source=polymark.et) — Professional prediction market aggregator and prime brokerage platform backed by Alliance DAO and CMT Digital, featuring advanced order execution, self-custodial trading, and institutional-grade tools across multiple prediction markets.
-- [OkayBet](https://www.okaybet.app/?utm_source=polymark.et) — Prediction market infrastructure platform that builds applications on top of prediction markets, featuring AI trading agents, market aggregation, and parlay betting across multiple platforms.
-
-## 🔔 Alerts
-
-- [Nevua Markets](https://nevua.markets/?utm_source=polymark.et) — Live Polymarket watchlists with real-time alerts—get instant updates on Telegram, Discord, webhooks, or your browser.
-- [PolyAlertHub](https://polyalerthub.com/?utm_source=polymark.et) — Get real-time alerts on profitable traders, whales, and market trends. Never miss an update—get alerts straight to your email or Telegram.
-- [Stand](https://www.stand.trade/?utm_source=polymark.et) — Track and copy trade Polymarket whales. Receive lightning fast alerts when prediction market traders make high-conviction moves.
-- [alerts chat](https://alerts.chat/?utm_source=polymark.et) — Telegram-native app providing customizable real-time alerts on price actions for Polymarket and Kalshi markets.
-- [BBB](https://docs.bbb.community?utm_source=polymark.et) — Exclusive gated boutique solution providing advanced on-chain trading tools and Polymarket intelligence alerts for researchers and traders, limited to 150 members with invitation-only access.
-- [ElonTweets Live](https://elontweets.live/?utm_source=polymark.et) — Real-time tracker of Elon Musk’s tweet activity and rhythm with instant Telegram notifications.
-- [Whale Tracker Livid](https://whale-tracker-livid.vercel.app/?utm_source=polymark.et) — Polymarket whale monitoring platform tracking high-value traders with $50,000+ portfolios , featuring tiered alert systems with free 1-hour delayed notifications and Pro real-time alerts ($29/month) for whale trades exceeding $1,000+ position changes, big bet signals at 2x+ average sizing, and performance-ranked leaderboards revealing smart money movements before market shifts.​
-- [PolySpy](https://t.me/PolySpy_bot?utm_source=polymark.et) — Telegram bot delivering instant notifications for new Polymarket markets with granular category filtering across Politics, Sports, Crypto, Finance, Tech, Culture, Geopolitics, and Events, plus subcategory selection and ignored tags management for spam-free, customized alert delivery enabling early market discovery and trading advantages.
-- [PolyIntel](https://t.me/PolyIntel_bot?utm_source=polymark.et) — Real-time Telegram bot service detecting whale movements and insider trading activity on Polymarket, featuring automated alerts every 10 minutes with comprehensive scoring systems, portfolio tracking, and probability analysis for suspicious trades.
-- [Polytrackerbot](https://x.com/polytrackerbot?utm_source=polymark.et) — Automated Twitter bot tracking high-conviction Polymarket whale and most profitable wallet activities, with focused filtering excluding sports betting and emphasizing buy-side positions, developed by @alfiethecrypto for insider trading signal detection.
-- [PolyCopy](#) — Real-time Polymarket trader tracking bot for Telegram that monitors trading activity, portfolios, and performance insights without requiring wallet connections or private keys.
-- [YN Signals](https://t.me/YNSignals?utm_source=polymark.et) — 24/7 prediction market alpha signal aggregator that monitors Polymarket, Kalshi, and Limitless Markets to provide timely alerts on new market creation, odds anomalies, large transactions, and insider wallet activities via Telegram.
-
-## 📊 Analytics Tools
-
-- [Polymarket Analytics](https://polymarketanalytics.com/?utm_source=polymark.et) — Global analytics platform providing comprehensive data on Polymarket traders, markets, positions, and trades.
-- [Polysights](https://app.polysights.xyz/?utm_source=polymark.et) — AI-powered Polymarket analytics with 30+ custom metrics, news insights, alerts, and AI-driven summaries.
-- [Hashdive](https://www.hashdive.com/?utm_source=polymark.et) — A platform designed to provide advanced Polymarket and Kalshi analytics, with a special focus on Smart Scores.
-- [Betmoar](https://www.betmoar.fun/?utm_source=polymark.et) — Web-based Polymarket trading terminal offering powerful search, real-time news, and unique market insights.
-- [Parsec](https://parsec.fi/polymarket?utm_source=polymark.et) — Parsec provides real-time data analytics and insights for Polymarkets, helping users make informed decisions.
-- [MobyScreener](https://www.mobyscreener.com/predictions-feed?utm_source=polymark.et) — Live feed tracking top Polymarket traders’ buys and sells in real time for actionable prediction market insights.
-- [PolyScope](https://discord.com/invite/polyscope?utm_source=polymark.et) — Free real-time monitoring suite for Polymarket tracking trending markets, odds changes, and smart trader activity.
-- [Monitor the Situation](https://monitorthesituation.lol/?utm_source=polymark.et) — Institutional-grade dashboard for live orderbooks and cross-market price comparison on Polymarket, Kalshi, and Limitless.
-- [PredictFolio](https://predictfolio.com?utm_source=polymark.et) — Free Polymarket trader analytics platform enabling users to analyze, compare, and track trading performance and statistics.
-- [PolymarketDash](https://www.polymarketdash.com/?utm_source=polymark.et) — Professional trader analytics and real-time monitoring tool for Polymarket, specializing in smart money tracking and in-depth data analysis.
-- [Pricediction](https://web3-pricediction.vercel.app/?utm_source=polymark.et) — AI-powered prediction market toolkit for deep research, automatic analysis, and direct trading on Kalshi and Polymarket.
-- [BetterAI](https://betterai.tools/?utm_source=polymark.et) — Multi-model AI-driven prediction platform delivering real-time, explainable insights for Polymarket and Kalshi.
-- [Polysimplr](https://www.polysimplr.com/?utm_source=polymark.et) — A user-friendly Polymarket interface with AI-powered chat and analysis—making prediction markets more accessible for all.
-- [Prediedge](#) — Real-time analytics and whale tracking platform for Polymarket and Kalshi, spotlighting large trades, insider activity, and market signals.
-- [PolyScan](https://polyscan.bet/?utm_source=polymark.et) — Prediction markets terminal for real-time tracking of top traders, liquidity flows, and actionable Polymarket analytics.
-- [Wethr](https://wethr.net/?utm_source=polymark.et) — Advanced real-time weather analytics platform optimized for Polymarket and Kalshi climate and temperature traders.
-- [Polytrend](https://www.polytrend.xyz/?utm_source=polymark.et) — Analytics platform providing whale tracking, market insights, and upcoming autonomous trading capabilities for Polymarket prediction markets.
-- [Predicting Top](https://predicting.top/?utm_source=polymark.et) — Real-time prediction market leaderboard tracking platform dubbed "Kolscan of Polymarket" that displays top traders' daily performance, wallet addresses, and P&L data across prediction market platforms.
-- [EventWaves](https://www.eventwaves.io/?utm_source=polymark.et) — Polymarket analytics platform for quickly identifying high-edge markets using trader skill analysis and momentum tracking.
-- [Mention Markets](https://mentionmarkets.com/?utm_source=polymark.et) — Advanced transcript search and analysis tool for prediction markets, tracking specific word mentions across political, corporate, and Federal Reserve transcripts.
-- [Wincy Polymarket Bot](https://t.me/wincy_polymarket_bot?utm_source=polymark.et) — Telegram bot providing instant analysis of Polymarket's top 5 largest position holders per market, revealing trader directions, position sizes, buy/sell activities, trade counts, total market trades, and direct profile links for identifying whale movements and early market opportunities through comprehensive position tracking.
-- [Predicts.guru](https://www.predicts.guru/?utm_source=polymark.et) — Advanced Polymarket analytics platform offering comprehensive wallet statistics, performance visualization, strategy analysis through interactive charts for trade activity, win chance distribution, risk profiles, P&L timelines, and upcoming features like market category breakdowns and leaderboards for identifying trading patterns and smart money movements.​
-- [PredScan](https://predscan.io?utm_source=polymark.et) — Independent Polymarket analytics platform providing comprehensive wallet performance tracking across prediction markets with daily P&L monitoring, win rate analysis, ROI calculations, leaderboard rankings, and detailed trader insights updated daily at 5PM UTC for data-driven investment decisions.
-- [PolyWallet](https://polywallet.info/?utm_source=polymark.et) — Comprehensive Polymarket analytics platform enabling deep wallet analysis, trader comparisons, and real-time tracking of up to 20 wallets with Telegram notifications, featuring leaderboards for volume and profit leaders, customizable column displays, and advanced portfolio insights for discovering winning strategies.​
-- [FirePolymarket](https://firepolymarket.com?utm_source=polymark.et) — Real-time Polymarket analytics platform tracking hot market movements and smart money flows, featuring comprehensive leaderboards categorizing traders as "Smart" or "Whale" types, detailed ROI and P&L metrics, market activity monitoring, and Fire Score analysis to identify trending opportunities.
-- [PolyTrack](https://polytrack.cash/?utm_source=polymark.et) — Next-generation insider trading detection platform for Polymarket featuring real-time monitoring, advanced filtering by probability and trade amounts, new whale wallet detection, 24/7 automated tracking, and severity scoring system with instant alerts for suspicious trading activity, offered as a premium service at $9.99/week.
-- [PolyInsider](https://polyinsider.io?utm_source=polymark.et) — Real-time Polymarket tracking dashboard specializing in whale trades and insider activity detection, featuring fresh wallet monitoring for $5,000+ first-time bets, comprehensive market analytics, profitable trader rankings, and customizable interface themes with global timezone support built by @caneleo55.
-- [Polymarket Elon Tracker](https://t.me/polymarketbetbot?utm_source=polymark.et) — Specialized Telegram bot that provides real-time tracking, analytics, and portfolio management for Elon Musk tweet count betting markets on Polymarket, featuring live counters, order book analysis, AI predictions, and intelligent alerts to optimize prediction market strategies.
-- [MentionMetrix](https://www.mentionmetrix.com/?utm_source=polymark.et) — Advanced analytics platform for prediction market traders analyzing keyword mentions in speeches, earnings calls, press events, and debates across major figures and companies, providing historical data, trend charts, and contextual excerpts to inform Kalshi and Polymarket betting strategies.
-- [Wandly](https://wandly.xyz/?utm_source=polymark.et) — Advanced prediction market analytics platform providing real-time data, filtering tools, and calendar-based event tracking for Polymarket and Kalshi markets across politics, sports, crypto, and entertainment.
-- [future fun](https://www.future.fun/?utm_source=polymark.et) — AION-powered prediction market terminal featuring the Scouter analytics tool with proprietary Edge Score rankings for Polymarket traders.
-- [Markium](https://markiumpro.com/?utm_source=polymark.et) — Comprehensive data analytics and trading platform for prediction markets that provides market aggregation, wallet analytics, leaderboards, and watchlist alerts across Polymarket and other prediction market platforms.
-- [PolyVision](https://polyvisionx.com) — Polymarket wallet analyzer providing copy trading scores (1-10), P&L analysis, risk metrics (Sharpe ratio, max drawdown), red flag detection, and market category breakdowns via Telegram bot, REST API, and MCP server for AI agents.
-
-## 🔹 Arbitrage tools
-
-- [ArbBets](https://getarbitragebets.com/?utm_source=polymark.et) — AI-driven platform identifying arbitrage and positive expected value (EV) opportunities across Polymarket, Kalshi, and sportsbooks.
-- [Eventarb](https://www.eventarb.com/?utm_source=polymark.et) — A free tool for calculating and alerting cross-platform arbitrage opportunities in prediction markets like Polymarket, Kalshi, and Robinhood.
-- [Polytrage](http://t.me/polytrage?utm_source=polymark.et) — Real-time Polymarket arbitrage alert service operating via Telegram channel, delivering automated arbitrage opportunity signals every 15 minutes with detailed bid-ask spreads, guaranteed profit calculations, and direct trading links for crypto markets.​
-- [PolyScalping](https://polyscalping.org/?utm_source=polymark.et) — Real-time analytical platform for detecting arbitrage and scalping opportunities across all Polymarket markets, featuring automated market scanning every 60 seconds, Telegram alerts, ROI calculations, and advanced filtering by spread, volume, liquidity, and market categories for maximizing trading profits.
-- [Polymarket JB Bot](https://t.me/polymarket_jb_bot?utm_source=polymark.et) — Open-source Telegram bot providing automated Polymarket arbitrage alerts, order book depth analysis, and market closing scanner with three-tier signal filtering, automatic translation, and one-click trading integration built by @123olp and freely deployed for community use.
-- [Prediction Hunt](https://predictionhunt.com/?utm_source=polymark.et) — Comprehensive prediction market aggregation platform providing real-time cross-exchange comparison, arbitrage detection, and smart matching across Kalshi, Polymarket, and PredictIt with data refreshed every five minutes to help users make data-driven decisions and spot market inefficiencies.​​
-
-## 📈 Dashboards
-
-- [Token Terminal](https://tokenterminal.com?utm_source=polymark.et) — Full-stack onchain data platform standardizing financial metrics for blockchains and dApps using traditional finance KPIs and frameworks.
-- [DefiLlama](https://defillama.com/?utm_source=polymark.et) — Largest DeFi data aggregator providing comprehensive analytics across TVL, volume, fees, revenue, and governance for 6,000+ protocols on 400+ blockchains.
-- [Pizzint Watch](https://www.pizzint.watch/?utm_source=polymark.et) — Real-time dashboard tracking Pentagon-area pizza activity and Polymarket signals for unique OSINT-based market insight.
-- [fergmolina](https://dune.com/fergmolina/polymarket-markets-data?utm_source=polymark.et) — Comprehensive Dune Analytics dashboard providing on-chain data visualization and analysis for Polymarket events, markets, and user activity using Gamma API integration.
-- [Metaforecast](https://metaforecast.org?utm_source=polymark.et) — Meta search engine and aggregator for finding, presenting, and sharing forecasts and probability estimates from multiple prediction markets and forecasting platforms.
-- [Zapper](https://zapper.xyz/apps/polymarket?utm_source=polymark.et) — Comprehensive Web3 asset management platform featuring integrated Polymarket position tracking, multi-chain portfolio monitoring, and DeFi protocol exploration across 50+ blockchains.
-- [LayerHub](https://layerhub.xyz/protocols/polymarket?utm_source=polymark.et) — Comprehensive on-chain analytics platform specializing in wallet activity analysis for crypto projects, featuring dedicated Polymarket analytics with real-time tracking and individual wallet performance insights.
-- [KuCoinVentures](https://dune.com/kucoinventures/trading-bots-on-polymarket?utm_source=polymark.et) — Comprehensive Dune Analytics dashboard tracking automated trading bot activity and market share across major Polymarket trading platforms.
-
-## 📡 Data
-
-- [sealaunch](https://dune.com/sealaunch/polymarket-trending-topics?utm_source=polymark.et) — Dune dashboard visualizing the world’s real-time headlines onchain—track top Polymarket markets, sentiment shifts, and conviction by 24h volume.
-- [filarm](https://dune.com/filarm/polymarket-activity?utm_source=polymark.et) — Comprehensive Dune analytics dashboard tracking Polymarket metrics, user activity, volume trends, and market insights by data analyst Filippo Armani.
-- [Artemis](https://app.artemisanalytics.com/sectors?tab=prediction_markets&utm_source=polymark.et) — Institutional-grade analytics on Polymarket and Kalshi, tracking spot volume, open interest, active users, and transaction flows in real time.
-- [Blockworks](https://blockworks.com/analytics/polymarket?utm_source=polymark.et) — Professional analytics suite tracking Polymarket’s onchain activity, trading volumes, wallet segments, and market trends—powered by Blockworks Research.
-- [Dunedata](https://dune.com/dunedata/prediction-markets?utm_source=polymark.et) — Comprehensive Dune dashboard tracking volume, open interest, users, and trends across Polymarket, Kalshi, Limitless, and Myriad.
-- [alexmccullough](https://dune.com/alexmccullough/how-accurate-is-polymarket#a-few-things-immediately-stand-out?utm_source=polymark.et) — Dune dashboard analyzing Polymarket’s prediction accuracy, bias, and outcome distributions across different timeframes and price buckets.
-- [TREMOR](https://www.tremor.live/?utm_source=polymark.et) — Comprehensive data terminal for Polymarket and Kalshi prediction markets featuring SQL analytics, AI assistant, and real-time market intelligence across 140K+ active markets with sub-second query performance.
-- [Goldsky](https://goldsky.com/?utm_source=polymark.et) — Blockchain data infrastructure powering Polymarket's real-time prediction market data processing and onchain-offchain integration.
-
-## 💸 DeFi
-
-- [Ostium](https://app.ostium.com/strategies?utm_source=polymark.et) — The first app for automating trading strategies on Polymarket data.
-- [Aura](https://aura.money/?utm_source=polymark.et) — Trade everything: Sports, Politics, Crypto Perps, RWA Perps, & more. Powered by: Polymarket, Hyperliquid.
-- [Gondor](https://gondor.fi/?utm_source=polymark.et) — DeFi protocol for borrowing against Polymarket positions, unlocking liquidity without closing trades.
-- [HyperOdd](https://hyperodd.com?utm_source=polymark.et) — Leveraged prediction market platform offering up to 20x leverage on politics, sports, crypto, and stocks.
-- [Robin](https://robin.markets?utm_source=polymark.et) — Yield-bearing prediction market platform enabling users to earn DeFi yields on Polymarket positions through automated capital deployment and delta-neutral strategies.
-- [Narrative](https://www.testnet.narrative.xyz/?utm_source=polymark.et) — Perpetual information markets platform offering continuous trading on evolving narratives with live news integration.
-
-## 📚 Educational Resources
-
-- [PolyNoob](https://polynoob.com/?utm_source=polymark.et) — Beginner-friendly encyclopedia and guide for navigating Polymarket prediction markets with strategies, trader insights, and educational content.
-- [The Oracle by Polymarket](https://news.polymarket.com/?utm_source=polymark.et) — Newsletter and podcast offering news, insights, and analysis from the world’s largest prediction market.
-- [PolymarketGuide](https://polymarketguide.gitbook.io/?utm_source=polymark.et) — Independent knowledge base explaining Polymarket resolution, precedents, and case studies for traders and oracle participants.
-
-## 🔹 Extensions
-
-- [PMs4X](https://chromewebstore.google.com/detail/prediction-markets-for-x/cpimmfoflnoomfabkemagplkjeaemndp?utm_source=item-share-x&utm_source=polymark.et) — Privacy-focused Chrome browser extension enabling seamless access to Polymarket directly from Twitter/X timelines, featuring instant prediction market discovery for tweets, real-time match detection with percentage accuracy, volume tracking, and zero data collection while requiring no signup or wallet connection.​
-
-## 🔹 Funds
-
-- [PolyFund](https://www.polyfund.so/?utm_source=polymark.et) — Decentralized platform that enables skilled predictors to manage funds and investors to benefit from their expertise on Polymarket prediction markets.
-
-## 🏗️ Infrastructure
-
-- [SEDA](https://docs.seda.xyz/home/for-developers/build-an-oracle-program?utm_source=polymark.et) — SEDA brings Polymarket’s entire market data layer onchain. Developers can use Oracle Programs to transform prediction markets into composable DeFi primitives—powering perpetuals, lending, arbitrage tools, and custom derivatives across chains.
-- [Compose](https://compose.build?utm_source=polymark.et) — Offchain-to-onchain orchestration framework enabling developers to build hybrid blockchain applications 95% faster with TypeScript and automated workflow management.
-
-## 📰 News
-
-- [PROPHET](https://www.prophetnotes.com/?utm_source=polymark.et) — Expert-backed prediction newsletter delivering data-driven insights on politics, finance, and geopolitics.
-- [DeepNewz](https://deepnewz.com/?utm_source=polymark.et) — AI-powered news app serving personalized, unbiased stories with real-time prediction market odds for every news.
-- [Prediction News](https://predictionnews.com/?utm_source=polymark.et) — Comprehensive news, analysis, and data-driven insights covering the growing prediction market industry.
-- [Stocktwits](https://stocktwits.com?utm_source=polymark.et) — World's largest social media platform for traders and investors with 10+ million users, featuring real-time market discussions and integrated prediction market probabilities.
-- [Boring News](https://www.notboring.co/?utm_source=polymark.et) — AI-powered daily news show that uses Polymarket prediction market odds as the foundation for unbiased, data-driven news delivery across YouTube, X, and podcast platforms.
-- [Polynews](https://polynews.in?utm_source=polymark.et) — Real-time news platform that transforms Polymarket prediction market odds into live headlines without editorial bias, featuring market-driven probability journalism, dark mode interface, and upcoming global visualization map to provide "Bloomberg terminal for everything" powered by trader sentiment rather than traditional media.
-- [Key.pro](https://key.pro/?utm_source=polymark.et) — AI-powered universal trading platform by HashKey featuring real-time news integration, automated trading agents, and comprehensive market access across crypto, stocks, prediction markets including Polymarket, and memecoins with institutional-grade security.
-
-## 🏛️ Official
-
-- [Polymarket Live Ticker](https://ticker.polymarket.com?utm_source=polymark.et) — Official Polymarket widget service that provides real-time prediction market data tickers for livestreams, websites, and mobile apps with seamless OBS integration.
-
-## 🟪 Others
-
-- [Kaito](https://yaps.kaito.ai/infomarkets?utm_source=polymark.et) — Web3 information platform tracking mindshare across multiple prediction market platforms with real-time analytics and creator leaderboards.
-- [Cookie fun](https://www.cookie.fun/tokens/polymarket?utm_source=polymark.et) — cookie.fun is the index & data layer for all AI agents shows top gainers regarding mindshare, smart following, engagement, and onchain data.
-- [Prediction Index](https://predictionindex.xyz/?utm_source=polymark.et) — Largest real-time directory and ranking dashboard for prediction markets—track, filter, and discover 140+ projects by chain, type, and status.
-- [Dexu](https://dexu.ai/project/polymarket?id=2037&utm_source=polymark.et) — AI-driven analytics platform for early trend detection and social attention quantification across prediction markets and crypto narratives.
-- [Prediction Markets Directory](https://frontseat.co/prediction-markets?utm_source=polymark.et) — The most comprehensive open directory of prediction market projects—explore, search, and discover nearly 100 platforms in one place.
-- [Polyteller](https://polyteller.com/?utm_source=polymark.et) — Free Chrome extension providing essential trading tools for Polymarket users including live countdowns, smart notifications, privacy mode, and trade safety features.
-- [UMA rocks](https://www.uma.rocks/?utm_source=polymark.et) — Automated UMA token delegation platform enabling passive income through oracle voting on Polymarket with 14% APR and self-custodial staking.
-- [PolyTimer](https://polytimer.fun/?utm_source=polymark.et) — Chrome extension providing timezone-aware countdowns and advanced analytics directly within Polymarket's interface for better trading decisions.
-- [PolyRewards](https://polyrewards.netlify.app?utm_source=polymark.et) — Independent tracking platform for Polymarket's Liquidity Rewards Program providing comprehensive leaderboard statistics, revealing that Polymarket has distributed nearly $11 million to liquidity providers with only 52,613+ users receiving rewards to date.
-- [PolyFakeIt](https://www.polyfakeit.com/?utm_source=polymark.et) — Mockup generator tool for creating authentic-looking simulated prediction market screenshots with customizable odds, charts, and betting interfaces inspired by Polymarket's design, offering "zero liquidity, infinite vibes" for entertainment, educational, and creative content purposes.
-- [Fake-A-Polymarket](https://fake-a-polymarket.com?utm_source=polymark.et) — Popular generator tool for creating realistic fake Polymarket prediction market charts with customizable odds, volatility, volume data, and chart patterns for marketing, entertainment, and educational purposes.
-- [Liquid](https://protocol.useliquid.xyz?utm_source=polymark.et) — Insurance protocol for prediction markets that enables traders to set customizable loss caps and receive cash-back protection through one-tap activation on any bet.
-- [PolyHedg](https://polyhedg.com/?utm_source=polymark.et) — Certainty-as-a-Service platform that transforms unpredictable corporate event risks into fixed, budgetable costs through automated Polymarket prediction market hedging strategies.
-
-## 🔹 Parlays
-
-- [Clutch](http://ape.clutch.market?utm_source=polymark.et) — World’s first fully on-chain decentralized parlay platform—combine Polymarket, sports, and political predictions for higher payouts on Arbitrum and ApeChain.
-- [PredictShark](https://www.predictshark.io/?utm_source=polymark.et) — On-chain prediction market parlay platform that allows users to combine multiple Polymarket events into single high-reward bets with exponential payouts, built trustlessly on Polygon using native USDC.
-- [BetStack](https://alpha.betstack.app?utm_source=polymark.et) — Sports betting application powered by Polymarket that enables users to combine multiple prediction market bets into sequential parlays with superior odds and live cashout functionality.
-
-## 🔹 Portfolio Tracking
-
-- [Polymarket Bros](http://brosonpm.trade?utm_source=polymark.et) — Community-focused whale tracking and copy trading platform monitoring Polymarket trades over $4,000 in real-time, featuring one-click trade replication, trader identification, win rate displays, verified whale badges, and 30-second auto-refresh functionality accessible free forever.
-- [PolyTracker](https://t.me/polytracker0_bot?utm_source=polymark.et) — Telegram bot for monitoring specified Polymarket wallet activities, providing real-time notifications on new transactions with market details and direct links, including commands for tracking, listing, and profile viewing, developed by @nlabplay with ongoing stability improvements.
-- [Polylerts](https://t.me/Polylerts_bot?utm_source=polymark.et) — Free Telegram bot that enables tracking up to 15 Polymarket wallets with real-time trade alerts, comprehensive analytical reports, and advanced watchlist management features to monitor and learn from top prediction market traders.
-- [Polycool](https://polycool.live/?utm_source=polymark.et) — Real-time Polymarket smart trader tracking platform that identifies and alerts users to big trades from the top 0.5% of wallets, providing "Bloomberg for prediction markets" via 24/7 Telegram notifications and copy trading opportunities to follow insider moves before odds shift.
-
-## 🤖 Trading Bots
-
-- [Polycule](https://www.polycule.trade/?utm_source=polymark.et) — Telegram bot for seamless Polymarket trading, enabling mobile, social, and group trades from anywhere in the world.
-- [Flipr](https://flipr.bot/?utm_source=polymark.et) — The defi layer for prediction markets. leverage, lending, and trading directly on x
-- [Polymtrade](https://polym.trade/?utm_source=polymark.et) — The first mobile trading terminal for Polymarket with AI-powered insights.
-- [okbet](https://tryokbet.com/?utm_source=polymark.et) — Telegram-based terminal for trading on Polymarket & Kalshi—trade, bet, and copy top performers with your friends, all from chat.
-- [Predictify](https://t.me/Predictify_bot?utm_source=polymark.et) — Telegram-based, fully on-chain aggregator for Polymarket and Solana prediction markets—trade, copy, and analyze on mobile.
-- [Fireplace](https://fireplace.gg/?utm_source=polymark.et) — Social news app powered by prediction markets. Scroll, bet, and compete with friends on real-time news markets, all built on Polymarket.
-- [Based](https://app.based.one/predict?utm_source=polymark.et) — Unified Hyperliquid trading platform integrating Polymarket prediction markets with $8+ billion lifetime trading volume, 10,000+ users, and omni-platform access enabling perpetual/spot crypto trading, on-chain stock trading, and prediction market betting with deep Hyperliquid hypercore integration for seamless fund transfers between perpetual and prediction accounts, plus 2 million Based Gold rewards per epoch for prediction market participants.​
-- [Berry](https://berryinvesting.com/?utm_source=polymark.et) — Mobile-first investing app enabling access to US stocks, ETFs, and prediction markets—no bank account required, Polymarket-powered.
-- [Rainmaker](https://rainmaker.fun/?utm_source=polymark.et) — AI agent-powered terminal unifying arbitrage, copy-trading, and analytics for Polymarket and Kalshi—featuring the Cloud9 Agentic Terminal.
-- [PolyBot](https://polybot.trading/?utm_source=polymark.et) — Fast, self-custodial Telegram trading bot for Polymarket featuring Gnosis Safe integration, gas-sponsored transactions, and seamless paste-to-trade functionality directly within chat.
-- [Polyburg](https://polyburg.com/?utm_source=polymark.et) — Real-time intelligence terminal for tracking Polymarket's most profitable traders through smart wallet monitoring, AI-powered insights, and instant Telegram alerts.
-- [Rocket](https://userocket.app/?utm_source=polymark.et) — cutting-edge prediction market aggregator designed to give you the edge in forecasting and market analysis.
-- [Polyswipe](https://polyswipe.io/?utm_source=polymark.et) — Tinder-style prediction market app that simplifies trading on Polymarket through intuitive swiping gestures, featuring instant trading, multi-channel onboarding, and social features for mainstream adoption.
-- [Datalayer](https://datalayer.xyz/?utm_source=polymark.et) — AI companion platform for onchain trading across memes, perps, yield farming, and prediction markets. Powered by Hyperliquid, Polymarket, Solana, BSC and Base.
-- [Predicton](https://predicton-guide.gitbook.io?utm_source=polymark.et) — Trade politics, news, and sports directly in Telegram, TON-native prediction market powered by Polymarket.
-- [PolyScope Bot](https://polyscope.gitbook.io?utm_source=polymark.et) — AI-powered wallet tracker and analytics bot providing real-time alerts, wallet profiling, and market insights for Polymarket and other prediction platforms.
-- [PolyFocus](https://t.me/polyfocusbot?utm_source=polymark.et) — Telegram-based trading bot for Polymarket with integrated copy trading, multi-chain wallet management, and advanced market discovery features.
-- [PolyXBot](https://www.polyxbot.org/?utm_source=polymark.et) — Advanced Solana-native Telegram bot that enables seamless Polymarket trading with AI-driven market analysis, cross-chain bridging, and comprehensive portfolio management directly within Telegram.
-- [AIXBET](https://www.aixbet.ai/?utm_source=polymark.et) — Autonomous AI-powered betting protocol that executes real trades on prediction markets like Polymarket using advanced AI models and smart money signals, operating 24/7 with profit-sharing mechanisms.
-- [Converge](https://converge.market?utm_source=polymark.et) — First prediction market aggregator and professional trading terminal unifying fragmented markets across Polymarket, Kalshi, and Limitless into one seamless platform featuring zero added fees, chain-agnostic architecture, custody-free operations, cross-venue arbitrage detection, and professional-grade tools for unified portfolio management.​
-- [Sharpe Terminal](https://beta.sharpeterminal.com/?utm_source=polymark.et) — Professional-grade trading terminal for prediction markets featuring advanced orders, comprehensive monitoring, and Bloomberg interface with integrated Polymarket social feeds and user analytics. Built by traders for traders, currently in public beta.
-- [Polylayer](https://polylayer.xyz?utm_source=polymark.et) — Comprehensive Layer 2 prediction finance ecosystem built on Polymarket featuring advanced trading terminals, leveraged trading, yield generation, automated strategies, and institutional-grade derivatives infrastructure.
-- [Betly](https://www.betly.trade/?utm_source=polymark.et) — Mobile-first prediction market interface that simplifies Polymarket and Kalshi trading through intuitive swipe gestures, combining social betting with Tinder-like user experience.
+## Lists
+- [0xperp](https://twitter.com/i/lists/1684720466500431872?s=20)
+- [Zeitgeist](https://twitter.com/i/lists/1506265087727837189?s=20)
+- [Insight](https://twitter.com/i/lists/1495912681827704835?s=20)


### PR DESCRIPTION
Adds [SettleRisk](https://settlerisk.com) to the APIs section.

SettleRisk is an API that provides:
- **Risk scoring** (0–100) with explainable driver attribution for prediction market contracts
- **Dispute pricing** adjustments (risk premium, capital lockup cost, fair spread in basis points)
- **Settlement delay modeling** (lognormal p50/p90/p99 estimates)
- Supports both **Polymarket** and **Kalshi**
- REST + gRPC, batch endpoints (up to 1,000 markets per call)

Live at https://settlerisk.com with docs, a free tier, and a live demo.