### PR TITLE
Add MolTrust — Trust Infrastructure for Prediction Market Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Perfect for traders, researchers, and quants who want a unified prediction-marke
 - [SEDA](https://docs.seda.xyz/home/for-developers/build-an-oracle-program?utm_source=polymark.et) — SEDA brings Polymarket’s entire market data layer onchain. Developers can use Oracle Programs to transform prediction markets into composable DeFi primitives—powering perpetuals, lending, arbitrage tools, and custom derivatives across chains.
 - [Compose](https://compose.build?utm_source=polymark.et) — Offchain-to-onchain orchestration framework enabling developers to build hybrid blockchain applications 95% faster with TypeScript and automated workflow management.
 - [Baozi.bet](https://baozi.bet) — Decentralized pari-mutuel prediction market protocol on Solana with boolean and race (multi-outcome) markets, an open-source [MCP server](https://github.com/bolivian-peru/baozi-mcp) for AI agent integration, affiliate system, creator profiles, and $BAOZI token revenue sharing for stakers.
+- [MolTrust](https://moltrust.ch) — Trust infrastructure for autonomous agents in prediction markets. Identity verification (W3C DIDs), reputation scoring, and Verifiable Credentials with Ed25519 signatures. Verify your counterparty before every trade. ([SDK](https://github.com/MoltyCel/moltrust-sdk) · `pip install moltrust` · [API Docs](https://api.moltrust.ch/docs))
 
 ## 📰 News
 


### PR DESCRIPTION
## Summary

Adds [MolTrust](https://moltrust.ch) to the **Infrastructure** section.

MolTrust provides trust infrastructure for autonomous agents in prediction markets:

- **Identity Verification** — W3C DID-based decentralized identities for agents
- **Reputation Scoring** — Peer-to-peer trust ratings between trading agents
- **W3C Verifiable Credentials** — Ed25519-signed credentials to verify your counterparty before every trade

## Links

- Website: https://moltrust.ch
- SDK: `pip install moltrust`
- API Docs: https://api.moltrust.ch/docs
- GitHub: https://github.com/MoltyCel/moltrust-sdk