### PR TITLE
Add PolyClawster — AI agent for Polymarket trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 > The most complete, community-maintained directory of prediction market tools — analytics platforms, trading bots, dashboards, APIs, data feeds, alert systems, educational resources, and more.  
 > Covering Polymarket, Kalshi, Manifold, Hyperliquid, and the wider forecasting ecosystem.
+- [PolyClawster](https://github.com/al1enjesus/polyclawster) - AI agent for Polymarket trading. Whale signal detection (200+ wallets), signal scoring 0-10, non-custodial. OpenClaw skill + Telegram Mini App. [Leaderboard](https://polyclawster.com/leaderboard)
 
 Pull requests welcome — add your tool or improve the list!
 


### PR DESCRIPTION
Adding [PolyClawster](https://github.com/al1enjesus/polyclawster) to the list.

**What it is:** AI agent skill for trading on Polymarket prediction markets.

**Key features:**
- Whale signal detection (tracks 200+ wallets with 58%+ win rate)
- Non-custodial (private key stays on your machine)
- Signal scoring 0-10
- Public leaderboard: [polyclawster.com/leaderboard](https://polyclawster.com/leaderboard)
- Works as OpenClaw AI skill or Telegram Mini App

**Stats:** 15 agents, 21 trades, 63% top win rate

Open source under MIT-0.