### PR TITLE
Add Parsec to APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Dome](https://domeapi.io?utm_source=polymark.et) — Developer infrastructure platform providing unified APIs and SDKs for accessing real-time and historical prediction market data across multiple platforms.
 - [PolyRouter](https://polyrouter.io?utm_source=polymark.et) — Unified API service that provides normalized prediction market data from Kalshi, Polymarket, Limitless, and other platforms through a single API key and standardized interface.
 - [PMXT](https://github.com/qoery-com/pmxt) - An open-source API for accessing prediction market data across multiple exchanges.
+- [Parsec](https://parsecapi.com) — HFT-focused, developer-first prediction market infrastructure for normalized market data, execution, and live streams across major venues. Generous free tier.
 
 ## 🔹 Aggregator
 


### PR DESCRIPTION
Parsec provides a unified API with execution across Polymarket, Kalshi, Opinion, Limitless, and PredictFun. TypeScript/Python SDKs, MCP server, WebSocket streams. Built in Rust. Free tier: 10K requests/month.