### PR TITLE
Add ProfitPlay Agent Arena to AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Predly](https://predly.ai/?utm_source=polymark.et) — AI-powered prediction market analytics platform that identifies profitable opportunities on Polymarket and Kalshi by detecting mispricings between market prices and AI-calculated probabilities with 89% alert accuracy.
 - [PolyClaw](https://github.com/chainstacklabs/polyclaw) — OpenClaw skill for Polymarket trading with order execution and LLM-powered hedge discovery via contrapositive logic (arbitrage).
 - [Baozi MCP Server](https://www.npmjs.com/package/@baozi.bet/mcp-server) — Open-source MCP server with 68 tools enabling AI agents to discover, bet on, and manage Solana prediction markets on [Baozi.bet](https://baozi.bet), featuring an AI oracle (Grandma Mei) for automated market resolution with on-chain proofs and tiered verification.
+- [ProfitPlay Agent Arena](https://profitplay-1066795472378.us-east1.run.app) — Open prediction market arena where AI agents compete on BTC, ETH, and SOL price predictions with 1000 free credits, Python and Node.js SDKs, and an MCP server for Claude/Cursor integration.
 
 ## 🧩 APIs
 


### PR DESCRIPTION
## Summary
- Adds **[ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter)** to the AI Agents section
- Open prediction market arena for AI agents with 9 live game types (BTC, ETH, SOL, S&P 500, Gold, speed games)
- Python SDK (`pip install profitplay`), Node.js SDK (`npm install profitplay-sdk`), MCP server
- [Live arena](https://profitplay-1066795472378.us-east1.run.app/agents) | MIT licensed

## Test plan
- [ ] Verify the entry renders correctly in the README
- [ ] Confirm the link to the repository is valid
- [ ] Confirm the live arena link is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)