### PR TITLE
Add Telonex - Historical tick-level data

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [alexmccullough](https://dune.com/alexmccullough/how-accurate-is-polymarket#a-few-things-immediately-stand-out?utm_source=polymark.et) — Dune dashboard analyzing Polymarket’s prediction accuracy, bias, and outcome distributions across different timeframes and price buckets.
 - [TREMOR](https://www.tremor.live/?utm_source=polymark.et) — Comprehensive data terminal for Polymarket and Kalshi prediction markets featuring SQL analytics, AI assistant, and real-time market intelligence across 140K+ active markets with sub-second query performance.
 - [Goldsky](https://goldsky.com/?utm_source=polymark.et) — Blockchain data infrastructure powering Polymarket's real-time prediction market data processing and onchain-offchain integration.
+- [Telonex](https://telonex.io/?utm_source=polymark.et) — Prediction market data platform providing tick-level historical trades, quotes, orderbooks, and on-chain fills via REST API and Python SDK.
 
 ## 💸 DeFi
 


### PR DESCRIPTION
Adding [Telonex](https://telonex.io) to the 📡 Data section — prediction market data platform providing tick-level historical trades, quotes, orderbooks, and on-chain fills via REST API and Python SDK.