### PR TITLE
Add Signals to Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 
 ## 🏗️ Infrastructure
 
+- [Signals Protocol](https://signals.wtf) — Range-based BTC prediction market on Citrea (Bitcoin L2). Binary markets only tell you "up or down" — Signals lets you predict exactly where BTC will close by picking a price range. The result isn't a single probability but a full distribution curve showing how much conviction the market has at every price level.
 - [SEDA](https://docs.seda.xyz/home/for-developers/build-an-oracle-program?utm_source=polymark.et) — SEDA brings Polymarket’s entire market data layer onchain. Developers can use Oracle Programs to transform prediction markets into composable DeFi primitives—powering perpetuals, lending, arbitrage tools, and custom derivatives across chains.
 - [Compose](https://compose.build?utm_source=polymark.et) — Offchain-to-onchain orchestration framework enabling developers to build hybrid blockchain applications 95% faster with TypeScript and automated workflow management.
 - [Baozi.bet](https://baozi.bet) — Decentralized pari-mutuel prediction market protocol on Solana with boolean and race (multi-outcome) markets, an open-source [MCP server](https://github.com/bolivian-peru/baozi-mcp) for AI agent integration, affiliate system, creator profiles, and $BAOZI token revenue sharing for stakers.


### PR DESCRIPTION
Adding [Signals](https://signals.wtf), a range-based BTC prediction market on Citrea (Bitcoin L2) that uses CLMSR mechanism. Instead of binary yes/no, users pick price ranges to predict where BTC will close.