### PR TITLE
Add pykalshi to APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Dome](https://domeapi.io?utm_source=polymark.et) — Developer infrastructure platform providing unified APIs and SDKs for accessing real-time and historical prediction market data across multiple platforms.
 - [PolyRouter](https://polyrouter.io?utm_source=polymark.et) — Unified API service that provides normalized prediction market data from Kalshi, Polymarket, Limitless, and other platforms through a single API key and standardized interface.
 - [PMXT](https://github.com/qoery-com/pmxt) - An open-source API for accessing prediction market data across multiple exchanges.
+- [pykalshi](https://github.com/ArshKA/kalshi-client) — Feature-rich Python client for Kalshi prediction markets with WebSocket streaming, automatic retries, rate limiting, pandas integration, Jupyter rendering, and local orderbook management.
 
 ## 🔹 Aggregator
 


### PR DESCRIPTION
Adds pykalshi — a feature-rich Python client for Kalshi prediction markets with WebSocket streaming, automatic retries, rate limiting, pandas integration, Jupyter rendering, and local orderbook management.

- **PyPI:** https://pypi.org/project/pykalshi/
- **GitHub:** https://github.com/ArshKA/kalshi-client