### PR TITLE
Add ScoreEdge to Alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Polytrackerbot](https://x.com/polytrackerbot?utm_source=polymark.et) — Automated Twitter bot tracking high-conviction Polymarket whale and most profitable wallet activities, with focused filtering excluding sports betting and emphasizing buy-side positions, developed by @alfiethecrypto for insider trading signal detection.
 - [PolyCopy](#) — Real-time Polymarket trader tracking bot for Telegram that monitors trading activity, portfolios, and performance insights without requiring wallet connections or private keys.
 - [YN Signals](https://t.me/YNSignals?utm_source=polymark.et) — 24/7 prediction market alpha signal aggregator that monitors Polymarket, Kalshi, and Limitless Markets to provide timely alerts on new market creation, odds anomalies, large transactions, and insider wallet activities via Telegram.
+- [ScoreEdge](https://scoreedge.app) — Real-time sports alerts for Kalshi and Polymarket traders. Set rules on score changes, lead flips, and play-by-play events — get notified via Telegram or email the moment something happens on the court or field, before markets reprice.
 
 ## 📊 Analytics Tools
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Polytrackerbot](https://x.com/polytrackerbot?utm_source=polymark.et) — Automated Twitter bot tracking high-conviction Polymarket whale and most profitable wallet activities, with focused filtering excluding sports betting and emphasizing buy-side positions, developed by @alfiethecrypto for insider trading signal detection.
 - [PolyCopy](#) — Real-time Polymarket trader tracking bot for Telegram that monitors trading activity, portfolios, and performance insights without requiring wallet connections or private keys.
 - [YN Signals](https://t.me/YNSignals?utm_source=polymark.et) — 24/7 prediction market alpha signal aggregator that monitors Polymarket, Kalshi, and Limitless Markets to provide timely alerts on new market creation, odds anomalies, large transactions, and insider wallet activities via Telegram.
-- [ScoreEdge](https://scoreedge.app) — Real-time sports alerts for Kalshi and Polymarket traders. Set rules on score changes, lead flips, and play-by-play events — get notified via Telegram or email the moment something happens on the court or field, before markets reprice.
+- [ScoreEdge](https://scoreedge.app?utm_source=github&utm_medium=awesome-list) — Real-time sports alerts for Kalshi and Polymarket traders. Set rules on score changes, lead flips, and play-by-play events — get notified via Telegram or email the moment something happens on the court or field, before markets reprice.
 
 ## 📊 Analytics Tools
 


### PR DESCRIPTION
ScoreEdge sends real-time sports alerts (score changes, lead flips, play-by-play) to Kalshi and Polymarket traders via Telegram or email — the only tool in this list tracking underlying sports events rather than market moves.