### PR TITLE
Add Signal — prediction market to equity signal dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 
 ## 📊 Analytics Tools
 
+- [Signal](https://pmse.netlify.app) — Free daily dashboard that aggregates financially relevant Polymarket and Kalshi markets, maps them to equity tickers (ETFs and individual stocks), and ranks by composite signal strength using sustained price, liquidity, and cross-platform consensus.
 - [Polymarket Analytics](https://polymarketanalytics.com/?utm_source=polymark.et) — Global analytics platform providing comprehensive data on Polymarket traders, markets, positions, and trades.
 - [Polysights](https://app.polysights.xyz/?utm_source=polymark.et) — AI-powered Polymarket analytics with 30+ custom metrics, news insights, alerts, and AI-driven summaries.
 - [Hashdive](https://www.hashdive.com/?utm_source=polymark.et) — A platform designed to provide advanced Polymarket and Kalshi analytics, with a special focus on Smart Scores.


### PR DESCRIPTION
Adds [Signal](https://pmse.netlify.app) to the Analytics Tools section.

Signal is a free daily dashboard that scrapes Polymarket and Kalshi, filters for financially relevant markets, maps them to equity tickers (ETFs and individual stocks), and ranks them by a composite score (sustained yes-price advantage, liquidity depth, cross-platform consensus). Output is a static page that rebuilds daily via GitHub Actions.