### PR TITLE
Add SuiBets - Decentralized sports betting protocol on Sui blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 
 - [Ostium](https://app.ostium.com/strategies?utm_source=polymark.et) — The first app for automating trading strategies on Polymarket data.
 - [Aura](https://aura.money/?utm_source=polymark.et) — Trade everything: Sports, Politics, Crypto Perps, RWA Perps, & more. Powered by: Polymarket, Hyperliquid.
+- [SuiBets](https://suibets.com/?utm_source=polymark.et) — Decentralized sports betting protocol on Sui blockchain with verified smart contract, multisig treasury, formal verification with 13 proven security properties, and instant on-chain settlement across 8+ sports.
 - [Gondor](https://gondor.fi/?utm_source=polymark.et) — DeFi protocol for borrowing against Polymarket positions, unlocking liquidity without closing trades.
 - [HyperOdd](https://hyperodd.com?utm_source=polymark.et) — Leveraged prediction market platform offering up to 20x leverage on politics, sports, crypto, and stocks.
 - [Robin](https://robin.markets?utm_source=polymark.et) — Yield-bearing prediction market platform enabling users to earn DeFi yields on Polymarket positions through automated capital deployment and delta-neutral strategies.


### PR DESCRIPTION
## Adding SuiBets under the DeFi section

SuiBets is a decentralized sports betting protocol on Sui blockchain — fits perfectly alongside the existing DeFi/trading tools in this list.

### What is SuiBets?
- Decentralized sports betting with instant on-chain settlement
- 8+ sports covered
- Verified smart contract on Suiscan
- 13 formally proven security properties (Sui Prover / Boogie / Z3)
- Multisig treasury protection
- SBETS governance token

### Links
- Website: https://suibets.com
- Verified Contract: https://suiscan.xyz/mainnet/object/0x4d83eab83defa9e2488b3c525f54fc588185cfc1a906e5dada1954bf52296e76
- Audit Report: https://suibets.com/audit-report.html
- Formal Verification: https://suibets.com/formal-verification.html