### PR TITLE
Add Settled — funding rate prediction markets on Solana

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [HyperOdd](https://hyperodd.com?utm_source=polymark.et) — Leveraged prediction market platform offering up to 20x leverage on politics, sports, crypto, and stocks.
 - [Robin](https://robin.markets?utm_source=polymark.et) — Yield-bearing prediction market platform enabling users to earn DeFi yields on Polymarket positions through automated capital deployment and delta-neutral strategies.
 - [Narrative](https://www.testnet.narrative.xyz/?utm_source=polymark.et) — Perpetual information markets platform offering continuous trading on evolving narratives with live news integration.
+- [Settled](https://www.settled.pro) — Prediction market platform for crypto perpetual futures funding rates on Solana. Binary YES/NO markets on whether the next funding rate will be positive, covering 2,400+ pairs across Binance, Bybit, Hyperliquid, KuCoin, and Gate. Markets auto-resolve every 1–8 hours from live exchange data with LMSR AMM pricing and Token-2022 conditional tokens.
 
 ## 📚 Educational Resources
 


### PR DESCRIPTION
## Adding Settled to the DeFi section

**Website:** https://www.settled.pro

Settled is a prediction market platform specifically for crypto perpetual futures funding rates, built on Solana. It's a genuine DeFi prediction market that fits this list well.

**Why it belongs here:**
- Binary YES/NO markets on whether the next funding rate settlement will be positive
- 2,400+ markets across Binance, Bybit, Hyperliquid, KuCoin, and Gate
- Markets auto-resolve every 1–8 hours from live exchange data — fully on-chain on Solana
- LMSR AMM with bounded LP loss — unique mechanism vs typical AMMs
- Token-2022 conditional tokens, USDC settlement
- Open-source resolver: https://github.com/Zirodelta/resolver

Distinct from Polymarket/Kalshi — purpose-built for derivatives market data, sub-daily resolution, and crypto-native crowd positioning rather than political/sports events.