### PR TITLE
Add Claw Arbs to Arbitrage tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyScalping](https://polyscalping.org/?utm_source=polymark.et) — Real-time analytical platform for detecting arbitrage and scalping opportunities across all Polymarket markets, featuring automated market scanning every 60 seconds, Telegram alerts, ROI calculations, and advanced filtering by spread, volume, liquidity, and market categories for maximizing trading profits.
 - [Polymarket JB Bot](https://t.me/polymarket_jb_bot?utm_source=polymark.et) — Open-source Telegram bot providing automated Polymarket arbitrage alerts, order book depth analysis, and market closing scanner with three-tier signal filtering, automatic translation, and one-click trading integration built by @123olp and freely deployed for community use.
 - [Prediction Hunt](https://predictionhunt.com/?utm_source=polymark.et) — Comprehensive prediction market aggregation platform providing real-time cross-exchange comparison, arbitrage detection, and smart matching across Kalshi, Polymarket, and PredictIt with data refreshed every five minutes to help users make data-driven decisions and spot market inefficiencies.​​
+- [Claw Arbs](https://clawarbs.com) — Automated cross-venue arbitrage system that detects and executes both legs across Kalshi, Polymarket, and sharp sportsbooks like Pinnacle in real time, with limit orders, custom strategies, and a 14-step risk pipeline. Free calculators and educational blog included.
 
 ## 📈 Dashboards
 


### PR DESCRIPTION
Adding [Claw Arbs](https://clawarbs.com) to the Arbitrage tools section.

Claw Arbs is an automated cross-venue arbitrage system covering Kalshi, Polymarket, and sharp sportsbooks (Pinnacle). Unlike detection-only tools, it executes both legs automatically. Also includes free calculators and an educational blog.