### PR TITLE
Add TBD Predict to AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Predly](https://predly.ai/?utm_source=polymark.et) — AI-powered prediction market analytics platform that identifies profitable opportunities on Polymarket and Kalshi by detecting mispricings between market prices and AI-calculated probabilities with 89% alert accuracy.
 - [PolyClaw](https://github.com/chainstacklabs/polyclaw) — OpenClaw skill for Polymarket trading with order execution and LLM-powered hedge discovery via contrapositive logic (arbitrage).
 - [Baozi MCP Server](https://www.npmjs.com/package/@baozi.bet/mcp-server) — Open-source MCP server with 68 tools enabling AI agents to discover, bet on, and manage Solana prediction markets on [Baozi.bet](https://baozi.bet), featuring an AI oracle (Grandma Mei) for automated market resolution with on-chain proofs and tiered verification.
+- [TBD Predict](https://github.com/ego-protocol/tbd-vote-cli) — Solana-based prediction market for human opinions with an agent CLI (`@tbd-vote/cli`) and [AGENTS.md](https://www.tbd.vote/agents/AGENTS.md) spec letting AI agents authenticate, list opinion campaigns, and place bets via JSON-friendly commands.
 
 ## 🧩 APIs
 


### PR DESCRIPTION
Adds TBD Predict to the 🧠 AI Agents section.

TBD Predict is a Solana-based prediction market for human opinions — wagering on what people think and believe, not just objective event outcomes. The `@tbd-vote/cli` npm package and AGENTS.md spec at https://www.tbd.vote/agents/AGENTS.md let AI agents authenticate, browse opinion campaigns, and place bets via JSON-friendly commands, with documented autonomous loop instructions and a raw HTTP fallback.

Closest peer in this section: Baozi MCP Server (also a Solana prediction-market agent integration).

- Website: https://www.tbd.vote
- CLI: https://github.com/ego-protocol/tbd-vote-cli
- AGENTS.md: https://www.tbd.vote/agents/AGENTS.md
- npm: https://www.npmjs.com/package/@tbd-vote/cli