### PR TITLE
Add Adanos Polymarket sentiment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 
 ## 🧩 APIs
 
+- [Adanos Market Sentiment API](https://api.adanos.org/docs/) — Polymarket sentiment API for stock and ETF tickers, providing buzz scores, trend signals, bullish/bearish sentiment, and compare endpoints for dashboards and trading tools.
 - [Adjacent News](https://adj.news/?utm_source=polymark.et) — Forward-looking news platform delivering prediction market-driven, contextual, and breaking news with advanced data and trading APIs.
 - [ClickHouse](https://crypto.clickhouse.com/?utm_source=polymark.et) — Open-source, columnar OLAP database delivering blazing-fast analytics for large-scale, real-time data across multiple industries.
 - [Dome](https://domeapi.io?utm_source=polymark.et) — Developer infrastructure platform providing unified APIs and SDKs for accessing real-time and historical prediction market data across multiple platforms.


### PR DESCRIPTION
## Summary
- Add Adanos Market Sentiment API to the APIs section as a Polymarket sentiment data source.
- Link directly to the public API documentation.

## Validation
- git diff --check