### PR TITLE
Add Helium to APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyRouter](https://polyrouter.io?utm_source=polymark.et) — Unified API service that provides normalized prediction market data from Kalshi, Polymarket, Limitless, and other platforms through a single API key and standardized interface.
 - [PMXT](https://github.com/qoery-com/pmxt) - An open-source API for accessing prediction market data across multiple exchanges.
 - [pykalshi](https://github.com/ArshKA/kalshi-client) — Feature-rich Python client for Kalshi prediction markets with WebSocket streaming, automatic retries, rate limiting, pandas integration, Jupyter rendering, and local orderbook management.
+- [Helium](https://heliumtrades.com/mcp-page/) — AI-powered market intelligence API with real-time news bias scoring across 5,000+ sources, probability-weighted stock/ETF/crypto forecasts, ML options pricing, and balanced multi-perspective news synthesis. Available as MCP server or REST API with free tier.
 
 ## 🔹 Aggregator
 


### PR DESCRIPTION
Adds [Helium](https://heliumtrades.com/mcp-page/) to the APIs section.

AI-powered market intelligence API providing:
- Real-time news search with bias scoring across 15+ dimensions (5,000+ sources)
- Probability-weighted stock/ETF/crypto price forecasts with AI bull/bear cases
- ML-powered options fair value pricing and probability ITM
- Balanced multi-perspective news synthesis
- 9 tools available via MCP protocol or REST API

Free tier (50 queries), no API key required.

GitHub: https://github.com/connerlambden/helium-mcp

Made with [Cursor](https://cursor.com)