### PR TITLE
Add Simmer to AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Predly](https://predly.ai/?utm_source=polymark.et) — AI-powered prediction market analytics platform that identifies profitable opportunities on Polymarket and Kalshi by detecting mispricings between market prices and AI-calculated probabilities with 89% alert accuracy.
 - [PolyClaw](https://github.com/chainstacklabs/polyclaw) — OpenClaw skill for Polymarket trading with order execution and LLM-powered hedge discovery via contrapositive logic (arbitrage).
 - [Baozi MCP Server](https://www.npmjs.com/package/@baozi.bet/mcp-server) — Open-source MCP server with 68 tools enabling AI agents to discover, bet on, and manage Solana prediction markets on [Baozi.bet](https://baozi.bet), featuring an AI oracle (Grandma Mei) for automated market resolution with on-chain proofs and tiered verification.
+- [Simmer](https://simmer.markets) — The agent harness for trading Polymarket and Kalshi autonomously. Bring your own agent (OpenClaw, Hermes, etc.), plug in remixable strategy skills, and add self-improving loops that learn from real outcomes. Paper trade with $SIM or graduate to live capital. Verified Polymarket builder. [Open-source SDK](https://github.com/SpartanLabsXyz/simmer-sdk).
 
 ## 🧩 APIs
 


### PR DESCRIPTION
Adding Simmer — the agent harness for trading Polymarket and Kalshi autonomously. Bring your own agent (OpenClaw, Hermes, etc.), plug in remixable strategy skills, and add self-improving loops that learn from real outcomes. Paper trade with $SIM or graduate to live capital.

Submitting to **🧠 AI Agents** alongside PolyClaw, Polyseer, Polybro, and Baozi MCP — Simmer is the platform-level peer in this category (multi-runtime, multi-venue, with a paper-trade rail).

- **Website:** https://simmer.markets
- **Docs:** https://docs.simmer.markets
- **Open-source SDK:** https://github.com/SpartanLabsXyz/simmer-sdk
- **ClawHub skill:** https://simmer.markets/skill.md
- **Status:** Verified Polymarket builder