### PR TITLE
Add TurbineFi - Build, Backtest, Deploy Trading Bots for Prediction Markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyClaw](https://github.com/chainstacklabs/polyclaw) — OpenClaw skill for Polymarket trading with order execution and LLM-powered hedge discovery via contrapositive logic (arbitrage).
 - [Baozi MCP Server](https://www.npmjs.com/package/@baozi.bet/mcp-server) — Open-source MCP server with 68 tools enabling AI agents to discover, bet on, and manage Solana prediction markets on [Baozi.bet](https://baozi.bet), featuring an AI oracle (Grandma Mei) for automated market resolution with on-chain proofs and tiered verification.
 - [Simmer](https://simmer.markets) — The agent harness for trading Polymarket and Kalshi autonomously. Bring your own agent (OpenClaw, Hermes, etc.), plug in remixable strategy skills, and add self-improving loops that learn from real outcomes. Paper trade with $SIM or graduate to live capital. Verified Polymarket builder. [Open-source SDK](https://github.com/SpartanLabsXyz/simmer-sdk).
+- [TurbineFi](https://turbinefi.com) — AI-powered algorithmic trading platform for prediction market trading on Kalshi and Polymarket, enabling users to build, backtest, and deploy thousands of automated trading bots in seconds. Combines trading strategy backtesting, prediction market analytics, and financial trading automation with AI-powered trading tools that generate, optimize, and execute strategies — including arbitrage trading strategies, market-making, and event-driven systems — without writing a single line of code.
 
 ## 🧩 APIs
 


### PR DESCRIPTION
Adds TurbineFi, a new tool to build, backtest, and deploy trading bots for prediction markets like Kalshi and Polymarket.

- Site: https://turbinefi.com/
- Contact: help@turbinefi.com
- X: https://x.com/turbinefi