### PR TITLE
Add PolyWhaleAlerts (sport-specific whale alerts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Polytrackerbot](https://x.com/polytrackerbot?utm_source=polymark.et) — Automated Twitter bot tracking high-conviction Polymarket whale and most profitable wallet activities, with focused filtering excluding sports betting and emphasizing buy-side positions, developed by @alfiethecrypto for insider trading signal detection.
 - [PolyCopy](#) — Real-time Polymarket trader tracking bot for Telegram that monitors trading activity, portfolios, and performance insights without requiring wallet connections or private keys.
 - [YN Signals](https://t.me/YNSignals?utm_source=polymark.et) — 24/7 prediction market alpha signal aggregator that monitors Polymarket, Kalshi, and Limitless Markets to provide timely alerts on new market creation, odds anomalies, large transactions, and insider wallet activities via Telegram.
+- [PolyWhaleAlerts](https://t.me/ThePolyAlerts) — Sport-specific Polymarket whale alert service tracking the top 150 wallets with dedicated channels for NFL, NBA, Soccer, Combat Sports, and Esports. Includes free tier, position context, decimal odds, win-rate display, and 7-day trial on paid tiers (from $19/mo).
 
 ## 📊 Analytics Tools
 


### PR DESCRIPTION
Adds [PolyWhaleAlerts](https://t.me/ThePolyAlerts) — a Polymarket whale alert service that segments alerts by sport (NFL, NBA, Soccer, Combat, Esports) rather than firing all whale trades into one feed. Tracks top 150 wallets with position context, win-rate display, and decimal odds. Free tier + paid channels from $19/mo with 7-day trial.