### PR TITLE
Adds Polyman to the Trading Bots section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 
 ## 🤖 Trading Bots
 
+- [Polyman](https://polyman.fun) — Telegram Mini App and web app for copy-trading top Polymarket traders, with AI-scored signals, proportional position mirroring, slippage guards, 
+  and deposits from 13 chains via the Polymarket Bridge.
 - [Polycule](https://www.polycule.trade/?utm_source=polymark.et) — Telegram bot for seamless Polymarket trading, enabling mobile, social, and group trades from anywhere in the world.
 - [Flipr](https://flipr.bot/?utm_source=polymark.et) — The defi layer for prediction markets. leverage, lending, and trading directly on x
 - [Polymtrade](https://polym.trade/?utm_source=polymark.et) — The first mobile trading terminal for Polymarket with AI-powered insights.


### PR DESCRIPTION
Polyman is a Telegram Mini App and web app for copy-trading top Polymarket traders. Features:
- Real-time signal feed with AI-scored traders
- Automatic position mirroring with proportional sizing and slippage guards
- Browse and buy any Polymarket market directly
- Deposits from 13 chains via the Polymarket Bridge

Links:
- App: https://app.polyman.fun
- Telegram: https://t.me/PolymanApp_bot
- Twitter: https://x.com/polymanfun