### PR TITLE
Add Datadash to the analytics tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyVision](https://polyvisionx.com) — Polymarket wallet analyzer providing copy trading scores (1-10), P&L analysis, risk metrics (Sharpe ratio, max drawdown), red flag detection, and market category breakdowns via Telegram bot, REST API, and MCP server for AI agents.
 - [pm.wiki](https://pm.wiki/?utm_source=polymark.et) — Independent prediction market directory and comparison tool with 350+ project profiles, covering exchanges, analytics tools, and ecosystem projects across the prediction market landscape.
 - [Polyguana](https://polyguana.com/?utm_source=polymark.et) — Independent Polymarket analytics platform featuring trader leaderboards, market statistics, and performance tracking for data-driven prediction market insights.
+- [Datadash](https://datadash.xyz) — Polymarket trading terminal that pairs deep wallet intelligence with native execution: build cohorts of traders by on-chain behavior, compare PnL curves, surface smart money, then trade the markets in the same interface.
 
 ## 🔹 Arbitrage tools
 


### PR DESCRIPTION
Adds **Datadash** ([datadash.xyz](https://datadash.xyz)) under **📊 Analytics Tools**.

Datadash is a Polymarket trading terminal that pairs wallet/cohort intelligence with native execution — build cohorts of traders by on-chain behavior, compare PnL curves, surface smart money, and trade the markets in the same interface (email & social login, no KYC). It fits the analytics category but adds in-app execution, so it complements the read-only dashboards already listed.

Entry added:

> - [Datadash](https://datadash.xyz) — Polymarket trading terminal that pairs deep wallet intelligence with native execution: build cohorts of traders by on-chain behavior, compare PnL curves, surface smart money, then trade the markets in the same interface. Email & social login, no KYC.

- Single bullet added under the existing `## 📊 Analytics Tools` header
- Follows the repo's `- [Name](url) — description.` format

Thanks for maintaining the list! 🙏