### PR TITLE
Add pmwatch - prediction market anomaly monitor for insider trading detection to Analytics Tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyVision](https://polyvisionx.com) — Polymarket wallet analyzer providing copy trading scores (1-10), P&L analysis, risk metrics (Sharpe ratio, max drawdown), red flag detection, and market category breakdowns via Telegram bot, REST API, and MCP server for AI agents.
 - [pm.wiki](https://pm.wiki/?utm_source=polymark.et) — Independent prediction market directory and comparison tool with 350+ project profiles, covering exchanges, analytics tools, and ecosystem projects across the prediction market landscape.
 - [Polyguana](https://polyguana.com/?utm_source=polymark.et) — Independent Polymarket analytics platform featuring trader leaderboards, market statistics, and performance tracking for data-driven prediction market insights.
+- [pmwatch](https://github.com/lweiss01/pmwatch) - Open-source anomaly detector for politically-sensitive Kalshi prediction markets. Monitors 33 high-MNPI-risk series and flags unusual volume spikes and price divergence that may indicate insider trading ahead of public announcements. Public API only, no auth required.
 
 ## 🔹 Arbitrage tools
 


### PR DESCRIPTION
Adds pmwatch under a the "Analytics Tools" section.

pmwatch is an open-source tool built in response to the George Santos/Kalshi 
insider trading investigation (June 2026). It monitors 33 politically-sensitive 
Kalshi series using only the public API and flags anomalous trading patterns 
that may precede public announcements.

- Repo: https://github.com/lweiss01/pmwatch
- No API key required
- Actively maintained (launched today, scheduler running)
- Includes collector, scorer, FastAPI backend, and live dashboard