### PR TITLE
Add TWZRD Agent Intel: on-chain trust MCP server for AI agents on Solana prediction markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Compose](https://compose.build?utm_source=polymark.et) — Offchain-to-onchain orchestration framework enabling developers to build hybrid blockchain applications 95% faster with TypeScript and automated workflow management.
 - [Baozi.bet](https://baozi.bet) — Decentralized pari-mutuel prediction market protocol on Solana with boolean and race (multi-outcome) markets, an open-source [MCP server](https://github.com/bolivian-peru/baozi-mcp) for AI agent integration, affiliate system, creator profiles, and $BAOZI token revenue sharing for stakers.
 - [OrderbookTrade](https://www.orderbook.trade) - High performance CLOB based Matching Engine and On-Chain Settlement for Prediction Markets, start your prediction market in 1-click with OrderbookTrade.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) — On-chain trust infrastructure MCP server for AI agents operating on prediction markets. Provides `resolve_agent`, `score_agent`, `preflight_check`, and `verify_trust_receipt` (free) plus `get_trust_receipt` for signed V5 receipts (paid via x402 USDC micropayment on Solana, <1s settlement). Zero-install MCP: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
 
 ## 📰 News
 


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) — MCP server providing on-chain trust scoring for AI agents operating with Solana payments.

AI agents call \`preflight_check\` before dispatching transactions, \`score_agent\` to query trust scores, and \`get_trust_receipt\` to mint a signed V5 receipt (paid via x402 USDC micropayment, <1s Solana settlement).

Zero-install: \`{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}\`

Added to the **Infrastructure** section as TWZRD Agent Intel is trust infrastructure for the AI agents listed in this repo: agents betting autonomously on Solana prediction markets (e.g. Baozi.bet, DFlow/oracle3) need to verify counterpart reputation before transacting. The MCP tools integrate directly into agent loops as a pre-transaction safety layer.