### PR TITLE
feat: add The Stall — 210 pay-per-call AI capabilities via x402 (MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PMXT](https://github.com/qoery-com/pmxt) - An open-source API for accessing prediction market data across multiple exchanges.
 - [pykalshi](https://github.com/ArshKA/kalshi-client) — Feature-rich Python client for Kalshi prediction markets with WebSocket streaming, automatic retries, rate limiting, pandas integration, Jupyter rendering, and local orderbook management.
 
+- [The Stall](https://the-stall.intuitek.ai/mcp) — x402-native MCP server with Polymarket-specific pay-per-call tools for AI agents: market intelligence (active markets, probabilities, volume trends), historical resolver accuracy scoring, category-level performance analytics, and sentiment-shift momentum detection. $0.005–$0.015 USDC per call on Base mainnet, no API key required. ([MCP Server](https://the-stall.intuitek.ai/mcp))
+
 ## 🔹 Aggregator
 
 - [Verso](https://www.verso.trading/?utm_source=polymark.et) — Professional-grade prediction market terminal that provides real-time market data, analytics, and news intelligence for Polymarket and Kalshi traders in a Bloomberg-style institutional interface.


### PR DESCRIPTION
## The Stall — 210 pay-per-call AI capabilities (v4.64.0)

**Live:** https://the-stall.intuitek.ai | **MCP:** https://the-stall.intuitek.ai/mcp

The Stall is an x402 MCP server with 210 pay-per-call capabilities — AI agents pay USDC per call, no API keys needed.

**Coverage:** stocks, crypto, DeFi, insider trades, Form 144 planned sales, options, macro, congressional trades, weather, cron tools, domain intel, and 185+ more.

**New in v4.64.0:**
- `form-144-intel` — SEC Form 144 planned insider sale filings (pre-Form 4 signal, from EDGAR)
- `cron-parser` — parse and explain cron expressions, return next N run times

```json
{
  "mcpServers": {
    "the-stall": {
      "type": "streamable-http",
      "url": "https://the-stall.intuitek.ai/mcp"
    }
  }
}
```

git: d25c40a | version: v4.64.0 | caps: 210
