### PR TITLE
Add polymarket-api-python to APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Marketlens](https://marketlens.trade/) — Data platform providing tick-level historical Polymarket order book and trade data through a Python SDK and backtesting REST API for quantitative research and strategy development.
 - [PolyRouter](https://polyrouter.io?utm_source=polymark.et) — Unified API service that provides normalized prediction market data from Kalshi, Polymarket, Limitless, and other platforms through a single API key and standardized interface.
 - [PMXT](https://github.com/qoery-com/pmxt) - An open-source API for accessing prediction market data across multiple exchanges.
+- [polymarket-api-python](https://github.com/antflow-live/polymarket-api-python) — Typed Python client for the Polymarket API: read Gamma markets, snapshot and stream the CLOB order book, generate idempotent client order ids, and place orders. MIT licensed.
 - [pykalshi](https://github.com/ArshKA/kalshi-client) — Feature-rich Python client for Kalshi prediction markets with WebSocket streaming, automatic retries, rate limiting, pandas integration, Jupyter rendering, and local orderbook management.
 
 ## 🔹 Aggregator


### PR DESCRIPTION
Adds **polymarket-api-python** — an open-source (MIT), typed Python client for the public Polymarket API: read Gamma markets, snapshot and stream the CLOB order book, generate idempotent client order ids, and place orders via the official client.

- Repo: https://github.com/antflow-live/polymarket-api-python
- PyPI: https://pypi.org/project/polymarket-api-python/
- Read/stream/analytics needs only `httpx` + `websockets`, no credentials. Includes a docs cookbook.

Placed in the APIs section next to the other open-source clients. Thanks for maintaining this list!