### PR TITLE
Add Do Not Act (dispute & resolution intelligence API) to APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyRouter](https://polyrouter.io?utm_source=polymark.et) — Unified API service that provides normalized prediction market data from Kalshi, Polymarket, Limitless, and other platforms through a single API key and standardized interface.
 - [PMXT](https://github.com/qoery-com/pmxt) - An open-source API for accessing prediction market data across multiple exchanges.
 - [pykalshi](https://github.com/ArshKA/kalshi-client) — Feature-rich Python client for Kalshi prediction markets with WebSocket streaming, automatic retries, rate limiting, pandas integration, Jupyter rendering, and local orderbook management.
+- [Do Not Act](https://donotact.com) — Dispute & Resolution Intelligence API for prediction-market agents: machine-readable DO_NOT_ACT from public UMA dispute history and settlement-rule ambiguity. Fail-closed, no execution. Agent-first with llms.txt, OpenAPI and an MCP server.
 
 ## 🔹 Aggregator
 


### PR DESCRIPTION
Adds **Do Not Act** to the APIs section — a Dispute & Resolution Intelligence API for prediction-market agents. Returns machine-readable READY / DO_NOT_ACT / INSUFFICIENT_EVIDENCE verdicts from public UMA dispute history and settlement-rule ambiguity (Polymarket; Kalshi next). Fail-closed, read-only, no execution. Agent-first: llms.txt, OpenAPI and an MCP server. Thanks for maintaining this list!