### PR TITLE
Add ContractTax to Analytics Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyVision](https://polyvisionx.com) — Polymarket wallet analyzer providing copy trading scores (1-10), P&L analysis, risk metrics (Sharpe ratio, max drawdown), red flag detection, and market category breakdowns via Telegram bot, REST API, and MCP server for AI agents.
 - [pm.wiki](https://pm.wiki/?utm_source=polymark.et) — Independent prediction market directory and comparison tool with 350+ project profiles, covering exchanges, analytics tools, and ecosystem projects across the prediction market landscape.
 - [Polyguana](https://polyguana.com/?utm_source=polymark.et) — Independent Polymarket analytics platform featuring trader leaderboards, market statistics, and performance tracking for data-driven prediction market insights.
+- * [ContractTax](https://www.contracttax.com) — Tax forms, P&L, and a Sharp Score for Kalshi traders. Upload your trade history for tax numbers under every treatment, full performance analytics, and a skill rating, plus free guides and calculators.
 
 ## 🔹 Arbitrage tools
 


### PR DESCRIPTION
ContractTax turns your Kalshi prediction-market trade history into tax forms, full P&L, and a Sharp Score that rates your edge. It models your tax bill under every treatment, since the tax status of event contracts is unsettled, and includes free guides and calculators. A prediction-market-specific alternative to general crypto tax tools.