### PR TITLE
Add India Predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Adjacent News](https://adj.news/?utm_source=polymark.et) — Forward-looking news platform delivering prediction market-driven, contextual, and breaking news with advanced data and trading APIs.
 - [ClickHouse](https://crypto.clickhouse.com/?utm_source=polymark.et) — Open-source, columnar OLAP database delivering blazing-fast analytics for large-scale, real-time data across multiple industries.
 - [Dome](https://domeapi.io?utm_source=polymark.et) — Developer infrastructure platform providing unified APIs and SDKs for accessing real-time and historical prediction market data across multiple platforms.
+- [India Predictions](https://www.indiapredictions.com/data) — Free, CORS-enabled JSON API aggregating Polymarket odds for India-focused markets (cricket/IPL, elections, RBI/Nifty, crypto, Bollywood), with embeddable per-market odds widgets.
 - [Marketlens](https://marketlens.trade/) — Data platform providing tick-level historical Polymarket order book and trade data through a Python SDK and backtesting REST API for quantitative research and strategy development.
 - [PolyRouter](https://polyrouter.io?utm_source=polymark.et) — Unified API service that provides normalized prediction market data from Kalshi, Polymarket, Limitless, and other platforms through a single API key and standardized interface.
 - [PMXT](https://github.com/qoery-com/pmxt) - An open-source API for accessing prediction market data across multiple exchanges.


### PR DESCRIPTION
Adding **India Predictions** under 🧩 APIs.

It's a free, watch-only tracker + data API for India-focused prediction markets, aggregating Polymarket odds across cricket/IPL, elections, RBI/Nifty, crypto, and Bollywood.

- Free public JSON API — no key, CORS-enabled: https://www.indiapredictions.com/api/markets
- Docs: https://www.indiapredictions.com/data
- Also ships embeddable per-market odds widgets
- No real money involved — informational tracker only

Entry placed alphabetically within the APIs section, matching the existing bullet/em-dash style.