### PR TITLE
Add PredMart

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 
 ## 💸 DeFi
 
+- [PredMart](https://predmart.com) — Margin account for Polymarket: trade with up to 5x leverage in one click, or unlock USDC from prediction-market shares you already hold. Non-custodial lending protocol on Polygon.
 - [Ostium](https://app.ostium.com/strategies?utm_source=polymark.et) — The first app for automating trading strategies on Polymarket data.
 - [Aura](https://aura.money/?utm_source=polymark.et) — Trade everything: Sports, Politics, Crypto Perps, RWA Perps, & more. Powered by: Polymarket, Hyperliquid.
 - [SuiBets](https://suibets.com/?utm_source=polymark.et) — Decentralized sports betting protocol on Sui blockchain with verified smart contract, multisig treasury, formal verification with 13 proven security properties, and instant on-chain settlement across 8+ sports.


### PR DESCRIPTION
Adds PredMart to the DeFi section.

PredMart is a non-custodial margin account for Polymarket — trade with up to 5x leverage in one click, or unlock USDC from prediction-market shares you already hold. Built on Polygon.

Website: https://predmart.com