### PR TITLE
Add DepthFeed (order-book depth API for Polymarket/Kalshi/Limitless)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Adanos Market Sentiment API](https://api.adanos.org/docs/) — Polymarket sentiment API for stock and ETF tickers, providing buzz scores, trend signals, bullish/bearish sentiment, and compare endpoints for dashboards and trading tools.
 - [Adjacent News](https://adj.news/?utm_source=polymark.et) — Forward-looking news platform delivering prediction market-driven, contextual, and breaking news with advanced data and trading APIs.
 - [ClickHouse](https://crypto.clickhouse.com/?utm_source=polymark.et) — Open-source, columnar OLAP database delivering blazing-fast analytics for large-scale, real-time data across multiple industries.
+- [DepthFeed](https://depthfeed.com) — Order-book depth API for Polymarket, Kalshi, and Limitless: the full historical and live bid/ask book (every level, both sides) over REST and WebSocket, each snapshot stamped with the underlying crypto price. Free tier.
 - [Dome](https://domeapi.io?utm_source=polymark.et) — Developer infrastructure platform providing unified APIs and SDKs for accessing real-time and historical prediction market data across multiple platforms.
 - [Marketlens](https://marketlens.trade/) — Data platform providing tick-level historical Polymarket order book and trade data through a Python SDK and backtesting REST API for quantitative research and strategy development.
 - [PolyRouter](https://polyrouter.io?utm_source=polymark.et) — Unified API service that provides normalized prediction market data from Kalshi, Polymarket, Limitless, and other platforms through a single API key and standardized interface.
@@ -179,6 +180,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [TREMOR](https://github.com/sculptdotfun/tremor) — Comprehensive data terminal for Polymarket and Kalshi prediction markets featuring SQL analytics, AI assistant, and real-time market intelligence across 140K+ active markets with sub-second query performance.
 - [Goldsky](https://goldsky.com/?utm_source=polymark.et) — Blockchain data infrastructure powering Polymarket's real-time prediction market data processing and onchain-offchain integration.
 - [Probalytics](https://probalytics.io) — Prediction market data infrastructure for Polymarket and Kalshi. REST API with unified schema, ClickHouse SQL access, and 200–500M orderbook updates/day at 1ms resolution — 100x more granular than alternatives. Parquet/S3 bulk exports.
+- [DepthFeed](https://depthfeed.com/historical-data) — Historical L2 order-book depth for Polymarket, Kalshi, and Limitless: event-driven capture, full bid/ask ladder (both sides), 90+ days, each snapshot stamped with the underlying crypto price. REST + WebSocket, backtest-ready.
 
 ## 💸 DeFi
 


### PR DESCRIPTION
Adds **DepthFeed** to **🧩 APIs** and **📡 Data**.

DepthFeed is an order-book *depth* API for prediction markets — it records the full historical and live bid/ask book (every price level and size, both sides, on every change) for Polymarket, Kalshi, and Limitless crypto markets, and serves it over REST + a live WebSocket in one identical JSON schema, each snapshot stamped with the underlying crypto reference price.

It complements the data entries already listed (Marketlens, Dome, PolyRouter, Probalytics): those focus on trades/aggregation/analytics, whereas DepthFeed's niche is full L2 order-book depth + history for backtesting. Public docs at https://depthfeed.com/docs, free tier, no card.

- Entries are one line each, matching the list's format.
- Links are clean canonical URLs (no utm params).