### PR TITLE
Add ATLAS Research to Analytics Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 
 ## 📊 Analytics Tools
 
+- [ATLAS Research](https://atlassignals.app) — Paper-verified prediction market research signals with a fully public, loss-inclusive track record. Free Telegram channels + live dashboard; educational research, not financial advice.
 - [Polymarket Analytics](https://polymarketanalytics.com/?utm_source=polymark.et) — Global analytics platform providing comprehensive data on Polymarket traders, markets, positions, and trades.
 - [Polysights](https://app.polysights.xyz/?utm_source=polymark.et) — AI-powered Polymarket analytics with 30+ custom metrics, news insights, alerts, and AI-driven summaries.
 - [Hashdive](https://www.hashdive.com/?utm_source=polymark.et) — A platform designed to provide advanced Polymarket and Kalshi analytics, with a special focus on Smart Scores.


### PR DESCRIPTION
Adding ATLAS Research to the Analytics Tools section. It's a paper-verified prediction market research project with a fully public track record (wins and losses published), free Telegram channels, and a live dashboard. Educational research only. Thanks for the open invitation in the README!