### PR TITLE
Add World Event Trading (W.E.T.) under Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [trade.fun](https://trade.fun/?utm_source=polymark.et) — Comprehensive multi-asset trading platform integrating Polymarket prediction markets, Solana memecoins, perpetuals with up to 40x leverage, and yield farming in one customizable interface, featuring zero gas fees, and MEV protection.
 - [TradeFox](https://thetradefox.com?utm_source=polymark.et) — Professional prediction market aggregator and prime brokerage platform backed by Alliance DAO and CMT Digital, featuring advanced order execution, self-custodial trading, and institutional-grade tools across multiple prediction markets.
 - [OkayBet](https://www.okaybet.app/?utm_source=polymark.et) — Prediction market infrastructure platform that builds applications on top of prediction markets, featuring AI trading agents, market aggregation, and parlay betting across multiple platforms.
+- [World Event Trading (W.E.T.)](https://www.worldeventtrading.com) — Neutral cross-venue aggregator that reports what the prediction market says for real-world events: implied probability, traded volume, and the Kalshi-vs-Polymarket divergence, with a documented methodology, per-event odds pages, and an embeddable odds widget.
 
 ## 🔔 Alerts
 


### PR DESCRIPTION
Adds World Event Trading - a neutral cross-venue aggregator that reports implied probability, traded volume, and the Kalshi-vs-Polymarket divergence per event, with a public methodology page and an embeddable odds widget. Fits the Aggregator section. Thanks for maintaining the list!