### PR TITLE
Add OVERROUND (skill-adjusted accuracy leaderboard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 ## 📊 Analytics Tools
 
 - [Polymarket Analytics](https://polymarketanalytics.com/?utm_source=polymark.et) — Global analytics platform providing comprehensive data on Polymarket traders, markets, positions, and trades.
-- [OVERROUND](https://overround.pro/) — Leaderboard ranking Polymarket wallets by skill-adjusted accuracy against the prices paid, with a public graded alert ledger and published out-of-time backtests.
+- [OVERROUND](https://www.overround.pro/?utm_source=polymark.et) — Grades Polymarket wallets on price-relative accuracy over independent resolved events; publishes its methodology and a graded ledger of every alert sent, losses included.
 - [Polysights](https://app.polysights.xyz/?utm_source=polymark.et) — AI-powered Polymarket analytics with 30+ custom metrics, news insights, alerts, and AI-driven summaries.
 - [Hashdive](https://www.hashdive.com/?utm_source=polymark.et) — A platform designed to provide advanced Polymarket and Kalshi analytics, with a special focus on Smart Scores.
 - [Betmoar](https://www.betmoar.fun/?utm_source=polymark.et) — Web-based Polymarket trading terminal offering powerful search, real-time news, and unique market insights.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 ## 📊 Analytics Tools
 
 - [Polymarket Analytics](https://polymarketanalytics.com/?utm_source=polymark.et) — Global analytics platform providing comprehensive data on Polymarket traders, markets, positions, and trades.
+- [OVERROUND](https://overround.pro/) — Leaderboard ranking Polymarket wallets by skill-adjusted accuracy against the prices paid, with a public graded alert ledger and published out-of-time backtests.
 - [Polysights](https://app.polysights.xyz/?utm_source=polymark.et) — AI-powered Polymarket analytics with 30+ custom metrics, news insights, alerts, and AI-driven summaries.
 - [Hashdive](https://www.hashdive.com/?utm_source=polymark.et) — A platform designed to provide advanced Polymarket and Kalshi analytics, with a special focus on Smart Scores.
 - [Betmoar](https://www.betmoar.fun/?utm_source=polymark.et) — Web-based Polymarket trading terminal offering powerful search, real-time news, and unique market insights.


### PR DESCRIPTION
Adds OVERROUND (https://overround.pro) to Analytics Tools.

It ranks Polymarket wallets by skill-adjusted accuracy against the prices they paid rather than P&L. Possibly useful for the list's readers: every alert it has ever sent is graded in public after resolution, losses included (overround.pro/receipts), and its rankings' out-of-time validation is published, including the windows that went against them (overround.pro/research). The #1 wallet per category is free.

Disclosure: I'm the builder. The entry carries the list's utm tag per your convention. Thanks for maintaining the list.
