### PR TITLE
Add AgentServices — x402-paid crypto/market data APIs for prediction market agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyRouter](https://polyrouter.io?utm_source=polymark.et) — Unified API service that provides normalized prediction market data from Kalshi, Polymarket, Limitless, and other platforms through a single API key and standardized interface.
 - [PMXT](https://github.com/qoery-com/pmxt) - An open-source API for accessing prediction market data across multiple exchanges.
 - [pykalshi](https://github.com/ArshKA/kalshi-client) — Feature-rich Python client for Kalshi prediction markets with WebSocket streaming, automatic retries, rate limiting, pandas integration, Jupyter rendering, and local orderbook management.
+- [AgentServices](https://agentservices.to) — 54 x402-paid crypto and market data APIs (prices, OHLCV, FX rates, on-chain analytics) with 37 MCP tools for AI agents building prediction market strategies.
 
 ## 🔹 Aggregator
 


### PR DESCRIPTION
## AgentServices

**Website:** https://agentservices.to
**API:** https://api.agentservices.to
**MCP Server:** `to.agentservices/agentservices` (official MCP Registry)

AgentServices provides 54 production data APIs with x402 on-chain payments (USDC on Base). Includes:

- **Crypto prices & OHLCV** — real-time and historical price data across major assets
- **FX rates** — live currency conversion
- **On-chain analytics** — blockchain data and market intelligence
- **Market analytics** — technical indicators and aggregated metrics

### Why it fits

Prediction market AI agents (like those already listed: Semantic 42, PolyClaw, oracle3) need reliable crypto market data. AgentServices provides these as x402-paid APIs with MCP tool access — agents can discover and pay per-call without API keys or subscriptions.

**Stats (Jul 2026):**
- 54 services, 97 endpoints
- 41 x402-paid endpoints ($0.01–$0.05/call)
- 37 MCP tools
- Official x402 Foundation compliant

Listed under **APIs** alongside other data feeds like PolyRouter and Marketlens.