### PR TITLE
Add PolyScore to Analytics Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyVision](https://polyvisionx.com) — Polymarket wallet analyzer providing copy trading scores (1-10), P&L analysis, risk metrics (Sharpe ratio, max drawdown), red flag detection, and market category breakdowns via Telegram bot, REST API, and MCP server for AI agents.
 - [pm.wiki](https://pm.wiki/?utm_source=polymark.et) — Independent prediction market directory and comparison tool with 350+ project profiles, covering exchanges, analytics tools, and ecosystem projects across the prediction market landscape.
 - [Polyguana](https://polyguana.com/?utm_source=polymark.et) — Independent Polymarket analytics platform featuring trader leaderboards, market statistics, and performance tracking for data-driven prediction market insights.
+- [PolyScore](https://polytrading.app) — Skill-vs-luck ratings for Polymarket traders: any wallet scored 0–100 from its full on-chain history (win rate, ROI, drawdown, diversification, consistency) with hard caps for small samples. Free wallet check.
 
 ## 🔹 Arbitrage tools
 


### PR DESCRIPTION
Adds PolyScore (polytrading.app) — free skill-vs-luck wallet ratings for Polymarket.
Scores 0–100 from full on-chain history, filters MM bots, hard-caps low-sample wallets. 900k+ trades indexed.

I'm the builder — happy to adjust the wording.