### PR TITLE
Add free Polymarket×Kalshi score-synced matched-book sample (Data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [TREMOR](https://github.com/sculptdotfun/tremor) — Comprehensive data terminal for Polymarket and Kalshi prediction markets featuring SQL analytics, AI assistant, and real-time market intelligence across 140K+ active markets with sub-second query performance.
 - [Goldsky](https://goldsky.com/?utm_source=polymark.et) — Blockchain data infrastructure powering Polymarket's real-time prediction market data processing and onchain-offchain integration.
 - [Probalytics](https://probalytics.io) — Prediction market data infrastructure for Polymarket and Kalshi. REST API with unified schema, ClickHouse SQL access, and 200–500M orderbook updates/day at 1ms resolution — 100x more granular than alternatives. Parquet/S3 bulk exports.
+- [Polymarket × Kalshi Score-Synced Matched Book (free sample)](https://huggingface.co/datasets/Coyevans/polymarket-kalshi-scoresync-orderbook-sample) — Free downloadable orderbook sample with game state (score/clock) attached to every row, Polymarket and Kalshi aligned in the same window, and settled outcomes labeled. One complete NBA OT game; Parquet/CSV. For research/backtesting — markets are efficient, this is training/research data, not a trading signal.
 
 ## 💸 DeFi
 


### PR DESCRIPTION
Adds a free, downloadable cross-venue matched-book sample (HuggingFace-hosted, CC BY-NC) to the Data section. Research/backtest data, clearly labeled not-a-signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)