### PR TITLE
Add Dino Markets to APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Adanos Market Sentiment API](https://api.adanos.org/docs/) — Polymarket sentiment API for stock and ETF tickers, providing buzz scores, trend signals, bullish/bearish sentiment, and compare endpoints for dashboards and trading tools.
 - [Adjacent News](https://adj.news/?utm_source=polymark.et) — Forward-looking news platform delivering prediction market-driven, contextual, and breaking news with advanced data and trading APIs.
 - [ClickHouse](https://crypto.clickhouse.com/?utm_source=polymark.et) — Open-source, columnar OLAP database delivering blazing-fast analytics for large-scale, real-time data across multiple industries.
+- [Dino Markets](https://dino.markets) — Matches the same event across Kalshi and Polymarket and flags arbitrage sized to fillable depth. REST, WebSocket, MCP. Free tier, 10k req/mo.
 - [Dome](https://domeapi.io?utm_source=polymark.et) — Developer infrastructure platform providing unified APIs and SDKs for accessing real-time and historical prediction market data across multiple platforms.
 - [Marketlens](https://marketlens.trade/) — Data platform providing tick-level historical Polymarket order book and trade data through a Python SDK and backtesting REST API for quantitative research and strategy development.
 - [PolyRouter](https://polyrouter.io?utm_source=polymark.et) — Unified API service that provides normalized prediction market data from Kalshi, Polymarket, Limitless, and other platforms through a single API key and standardized interface.


### PR DESCRIPTION
Adds [Dino Markets](https://dino.markets) to the APIs section (alphabetical, between Adjacent News and Dome).

Cross-venue data API: matches the same event across Kalshi and Polymarket and flags arbitrage sized to fillable depth, over REST, WebSocket, and MCP. Free tier available. Operated by Nusantara Ventures LLC — self-submission, following the same format as the neighboring entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)