### PR TITLE
Add Spectral Edge to Alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Polytrackerbot](https://x.com/polytrackerbot?utm_source=polymark.et) — Automated Twitter bot tracking high-conviction Polymarket whale and most profitable wallet activities, with focused filtering excluding sports betting and emphasizing buy-side positions, developed by @alfiethecrypto for insider trading signal detection.
 - [PolyCopy](https://polycopy.app) — Real-time Polymarket trader tracking bot for Telegram that monitors trading activity, portfolios, and performance insights without requiring wallet connections or private keys.
 - [YN Signals](https://t.me/YNSignals?utm_source=polymark.et) — 24/7 prediction market alpha signal aggregator that monitors Polymarket, Kalshi, and Limitless Markets to provide timely alerts on new market creation, odds anomalies, large transactions, and insider wallet activities via Telegram.
+- [Spectral Edge](https://app.cotes.ai) — Physics-trained AI for Kalshi x Polymarket BTC markets: a patent-pending engine decomposes live price into its component waves and scores how tightly they resonate. The Spectral Engine generates live UP / DOWN signals, backed by a confidence and edge rating. Available on desktop, mobile, and API — and signal replay and signal history of every settled round are free.
 
 ## 📊 Analytics Tools
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Polytrackerbot](https://x.com/polytrackerbot?utm_source=polymark.et) — Automated Twitter bot tracking high-conviction Polymarket whale and most profitable wallet activities, with focused filtering excluding sports betting and emphasizing buy-side positions, developed by @alfiethecrypto for insider trading signal detection.
 - [PolyCopy](https://polycopy.app) — Real-time Polymarket trader tracking bot for Telegram that monitors trading activity, portfolios, and performance insights without requiring wallet connections or private keys.
 - [YN Signals](https://t.me/YNSignals?utm_source=polymark.et) — 24/7 prediction market alpha signal aggregator that monitors Polymarket, Kalshi, and Limitless Markets to provide timely alerts on new market creation, odds anomalies, large transactions, and insider wallet activities via Telegram.
-- [Spectral Edge](https://app.cotes.ai) — Physics-trained AI for Kalshi x Polymarket BTC markets: a patent-pending engine decomposes live price into its component waves and scores how tightly they resonate. The Spectral Engine generates live UP / DOWN signals, backed by a confidence and edge rating. Available on desktop, mobile, and API — and signal replay and signal history of every settled round are free.
+- [Spectral Edge](https://spectralbot.cotes.ai) — Physics-trained AI for Kalshi x Polymarket BTC markets: a patent-pending engine decomposes live price into its component waves and scores how tightly they resonate. The Spectral Engine generates live UP / DOWN signals, backed by a confidence and edge rating. Available on desktop, mobile, and API — and signal replay and signal history of every settled round are free.
 
 ## 📊 Analytics Tools
 


### PR DESCRIPTION
Adds **Spectral Edge** (https://spectralbot.cotes.ai) under 🔔 Alerts.

Spectral Edge is physics-trained AI applied to prediction markets. Rather than learning from order flow or wallet behaviour, the patent-pending engine treats a live market as a waveform: it decomposes price into its component waves, measures how tightly those waves resonate, and scores the result into a directional signal.

The Spectral Engine generates live UP / DOWN signals on BTC markets across Kalshi and Polymarket, each backed by a confidence and edge rating. Signals are available on desktop and mobile — including lock-screen push from the installable PWA — and over a public API and MCP server for agent use. Replay of any settled round and full signal history are free, no account tier required.

Distinct from the other Alerts entries: those track wallets, whales, and new-market creation. This is model-generated price-direction signal from a decomposition method nothing else in the list uses.

One line added to the Alerts section, matching existing entry format. Happy to move it to 🧠 AI Agents or 📊 Analytics Tools, or trim, if you'd prefer.

