### PR TITLE
Add Stryke prediction market platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Gondor](https://gondor.fi/?utm_source=polymark.et) — DeFi protocol for borrowing against Polymarket positions, unlocking liquidity without closing trades.
 - [HyperOdd](https://hyperodd.com?utm_source=polymark.et) — Leveraged prediction market platform offering up to 20x leverage on politics, sports, crypto, and stocks.
 - [Robin](https://robin.markets?utm_source=polymark.et) — Yield-bearing prediction market platform enabling users to earn DeFi yields on Polymarket positions through automated capital deployment and delta-neutral strategies.
+- [Stryke](https://stryketrade.com?utm_source=polymark.et) - Solana native prediction markets. Bond curve trading so no seeded liquidity is required. Trade brand new Memecoins through to Majors, Sport & Politics etc.
 
 ## 📚 Educational Resources
 


### PR DESCRIPTION
## Summary

- add Stryke to the trading platforms list
- describe its Solana-native bonding curve markets