### PR TITLE
Add 0xinsider to Analytics Tools and APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyRouter](https://polyrouter.io?utm_source=polymark.et) — Unified API service that provides normalized prediction market data from Kalshi, Polymarket, Limitless, and other platforms through a single API key and standardized interface.
 - [PMXT](https://github.com/qoery-com/pmxt) - An open-source API for accessing prediction market data across multiple exchanges.
 - [pykalshi](https://github.com/ArshKA/kalshi-client) — Feature-rich Python client for Kalshi prediction markets with WebSocket streaming, automatic retries, rate limiting, pandas integration, Jupyter rendering, and local orderbook management.
+- [0xinsider API & MCP](https://0xinsider.com/developers?utm_source=polymark.et) — REST API and MCP server exposing normalized Polymarket and Kalshi trader data, including trader grades, large trades, smart money direction, and suspicious-activity flags, with an OpenAPI spec.
 
 ## 🔹 Aggregator
 
@@ -147,6 +148,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyVision](https://polyvisionx.com) — Polymarket wallet analyzer providing copy trading scores (1-10), P&L analysis, risk metrics (Sharpe ratio, max drawdown), red flag detection, and market category breakdowns via Telegram bot, REST API, and MCP server for AI agents.
 - [pm.wiki](https://pm.wiki/?utm_source=polymark.et) — Independent prediction market directory and comparison tool with 350+ project profiles, covering exchanges, analytics tools, and ecosystem projects across the prediction market landscape.
 - [Polyguana](https://polyguana.com/?utm_source=polymark.et) — Independent Polymarket analytics platform featuring trader leaderboards, market statistics, and performance tracking for data-driven prediction market insights.
+- [0xinsider](https://0xinsider.com/?utm_source=polymark.et) — Real-time prediction market intelligence terminal for Polymarket and Kalshi, tracking 7,000+ traders with 40+ quant metrics, S-F trader grades, trade signal scoring, smart money flow, and suspicious-activity detection.
 
 ## 🔹 Arbitrage tools
 


### PR DESCRIPTION
Adding 0xinsider in two sections, with the `utm_source=polymark.et` parameter the list uses.

**Analytics Tools** — it grades every Polymarket wallet S through F from that wallet's settled record, using Bayesian shrinkage across six metrics so one lucky market does not produce an S, then streams $10k+ trades tagged with the grade of the wallet behind each one. Trader pages carry P&L, Sharpe, max drawdown, win rate and per-category splits for 7,000+ ranked traders.

**APIs** — REST API and MCP server over the same data, spec at https://0xinsider.com/api/v1/openapi.json.

I opened this in August describing the product as covering Polymarket and Kalshi. Kalshi coverage has since been retired, so both entries now say Polymarket only. Rebased on current main.

Disclosure: I build it.