### PR TITLE
Add Polymarket Academy to Educational Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyNoob](https://polynoob.com/?utm_source=polymark.et) — Beginner-friendly encyclopedia and guide for navigating Polymarket prediction markets with strategies, trader insights, and educational content.
 - [The Oracle by Polymarket](https://news.polymarket.com/?utm_source=polymark.et) — Newsletter and podcast offering news, insights, and analysis from the world’s largest prediction market.
 - [PolymarketGuide](https://polymarketguide.gitbook.io/?utm_source=polymark.et) — Independent knowledge base explaining Polymarket resolution, precedents, and case studies for traders and oracle participants.
+- [Polymarket Academy](https://polymarketacademy.com/) — Independent guides and bot reviews for Polymarket copy trading, covering copy trading mechanics, wallet evaluation, risk management, and side-by-side comparisons of the main copy trading bots.
 
 ## 🔹 Extensions
 


### PR DESCRIPTION
Independent education site for Polymarket copy trading. Covers copy trading mechanics, wallet evaluation, and risk management, plus reviews of the main copy trading bots with a published review methodology. Not affiliated with Polymarket.