### PR TITLE
Add pm-kalshi-adjudication to Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [TREMOR](https://github.com/sculptdotfun/tremor) — Comprehensive data terminal for Polymarket and Kalshi prediction markets featuring SQL analytics, AI assistant, and real-time market intelligence across 140K+ active markets with sub-second query performance.
 - [Goldsky](https://goldsky.com/?utm_source=polymark.et) — Blockchain data infrastructure powering Polymarket's real-time prediction market data processing and onchain-offchain integration.
 - [Probalytics](https://probalytics.io) — Prediction market data infrastructure for Polymarket and Kalshi. REST API with unified schema, ClickHouse SQL access, and 200–500M orderbook updates/day at 1ms resolution — 100x more granular than alternatives. Parquet/S3 bulk exports.
+- [pm-kalshi-adjudication](https://github.com/imkane/pm-kalshi-adjudication) - Read-only measurement of whether Polymarket and Kalshi contracts with similar titles are the same contract, with 30 hand-adjudicated pairs and a documented taxonomy of how cross-venue matches fail.
 
 ## 💸 DeFi
 


### PR DESCRIPTION
Adds one entry to **Data**.

[pm-kalshi-adjudication](https://github.com/imkane/pm-kalshi-adjudication) is a read-only measurement of whether Polymarket and Kalshi contracts with similar titles are actually the same contract. It enumerates both venues, implements both fee models, and includes an IDF-weighted candidate matcher, a Gamma keyset pagination probe, an intra-Polymarket complement scanner and a hedge walker.

Of 30 candidate pairs hand-read against the full published resolution text on both venues, 3 were the same contract. The other 27 are written up as a taxonomy of how they failed: same city resolving against different weather stations, cumulative thresholds against exclusive buckets, window seams, event against announcement, race against standalone, complementary framings where the polarity inverts, and Kalshi rule templates published with placeholders unfilled.

It sits closer to research than tooling, so decline it freely if that puts it out of scope. The parts most likely to help someone building from this list are the API trap appendix and the failure taxonomy, since both are things people otherwise rediscover the expensive way.

MIT. Read-only against public endpoints, no keys, no order placement.