### PR TITLE
Add Kalshi × Polymarket Spreads (open dataset + methodology) to Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [TREMOR](https://github.com/sculptdotfun/tremor) — Comprehensive data terminal for Polymarket and Kalshi prediction markets featuring SQL analytics, AI assistant, and real-time market intelligence across 140K+ active markets with sub-second query performance.
 - [Goldsky](https://goldsky.com/?utm_source=polymark.et) — Blockchain data infrastructure powering Polymarket's real-time prediction market data processing and onchain-offchain integration.
 - [Probalytics](https://probalytics.io) — Prediction market data infrastructure for Polymarket and Kalshi. REST API with unified schema, ClickHouse SQL access, and 200–500M orderbook updates/day at 1ms resolution — 100x more granular than alternatives. Parquet/S3 bulk exports.
+- [Kalshi × Polymarket Spreads](https://github.com/nanare-sudo/kalshi-polymarket-spreads) — Open dataset, notebook and methodology for cross-venue analysis: verified Kalshi/Polymarket market matches with confidence scores, and *executable* spreads computed by walking both orderbooks at target order sizes net of fees (first public scan: 47% of observed spreads are negative once depth and fees are applied).
 
 ## 💸 DeFi
 


### PR DESCRIPTION
Adds an open-source dataset and methodology repo for cross-venue prediction-market analysis to the **Data** section.

**What it adds that isn't in the list yet:** every existing arbitrage/analytics entry reports price *differences*. This one publishes the **executable** spread — simulated by walking both real orderbooks at $100/$1,000 order sizes and applying Kalshi's `0.07·p·(1−p)` fee per fill level — alongside a confidence score for whether the two contracts are actually equivalent (3-stage matching: category/date blocking → IDF-weighted token overlap → resolution-rule verification).

The headline result from the first public scan (1,600 markets, 312 candidates, 17 verified matches): **47% of observed cross-venue spreads are negative once fees and depth are applied.** The repo ships the sample data (CSV/JSON), an executed Jupyter notebook with the chart, Python/JS/MCP examples, and full methodology including limitations.

**Disclosure:** I'm the author of the repo and of the Apify actor that generates the data. The repo itself is MIT-licensed, the sample data and notebook are free and self-contained, and the methodology documents its own failure modes. Happy to move it to `Arbitrage tools` or reword the entry if you prefer.

Repo: https://github.com/nanare-sudo/kalshi-polymarket-spreads