### PR TITLE
Add 0xArchive to prediction-market APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 
 ## 🧩 APIs
 
+- [0xArchive](https://www.0xarchive.io/) - Real-time and historical Hyperliquid market data, including HIP-4 outcome markets, via REST and WebSocket.
 - [Adanos Market Sentiment API](https://api.adanos.org/docs/) — Polymarket sentiment API for stock and ETF tickers, providing buzz scores, trend signals, bullish/bearish sentiment, and compare endpoints for dashboards and trading tools.
 - [Adjacent News](https://adj.news/?utm_source=polymark.et) — Forward-looking news platform delivering prediction market-driven, contextual, and breaking news with advanced data and trading APIs.
 - [ClickHouse](https://crypto.clickhouse.com/?utm_source=polymark.et) — Open-source, columnar OLAP database delivering blazing-fast analytics for large-scale, real-time data across multiple industries.


### PR DESCRIPTION
## Summary

Adds 0xArchive to the existing `🧩 APIs` section in `README.md`.

0xArchive provides real-time and historical Hyperliquid market data, including HIP-4 outcome markets, via REST and WebSocket APIs.

## Why

This is a direct fit for the repository’s API and data-feed directory. The prediction-market relevance is specifically Hyperliquid HIP-4; this entry does not imply Polymarket or Kalshi support.

Disclosure: 0xArchive is a commercial service; a free tier is available.

## Validation

* Confirmed the existing `🧩 APIs` section and formatting.
* Added one README line only.
* No code, dependencies, or unrelated entries were modified.
* Confirmed no existing 0xArchive PR or issue was found.
