### PR TITLE
Add DG3 to prediction market analytics tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [PolyVision](https://polyvisionx.com) — Polymarket wallet analyzer providing copy trading scores (1-10), P&L analysis, risk metrics (Sharpe ratio, max drawdown), red flag detection, and market category breakdowns via Telegram bot, REST API, and MCP server for AI agents.
 - [pm.wiki](https://pm.wiki/?utm_source=polymark.et) — Independent prediction market directory and comparison tool with 350+ project profiles, covering exchanges, analytics tools, and ecosystem projects across the prediction market landscape.
 - [Polyguana](https://polyguana.com/?utm_source=polymark.et) — Independent Polymarket analytics platform featuring trader leaderboards, market statistics, and performance tracking for data-driven prediction market insights.
+- [DG3](https://dg3.trade/terminal) — Prediction market research and analytics terminal for Polymarket, featuring +EV market ranking against no-vig fair odds, order book depth, sharp flow tracking, live team stats, and one-click execution in a single panel.
 
 ## 🔹 Arbitrage tools
 


### PR DESCRIPTION
Adding DG3, a prediction market research and analytics terminal covering Polymarket. Verified Polymarket builder. Placed in Analytics Tools alongside comparable platforms.