### PR TITLE
Add Kairos to Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [trade.fun](https://trade.fun/?utm_source=polymark.et) — Comprehensive multi-asset trading platform integrating Polymarket prediction markets, Solana memecoins, perpetuals with up to 40x leverage, and yield farming in one customizable interface, featuring zero gas fees, and MEV protection.
 - [TradeFox](https://thetradefox.com?utm_source=polymark.et) — Professional prediction market aggregator and prime brokerage platform backed by Alliance DAO and CMT Digital, featuring advanced order execution, self-custodial trading, and institutional-grade tools across multiple prediction markets.
 - [OkayBet](https://www.okaybet.app/?utm_source=polymark.et) — Prediction market infrastructure platform that builds applications on top of prediction markets, featuring AI trading agents, market aggregation, and parlay betting across multiple platforms.
+- [Kairos](https://kairos.trade/?utm_source=polymark.et) — Free cross-venue prediction market trading terminal that merges Kalshi, Polymarket, and Predict.fun order books into one ladder with NBBO routing to whichever venue shows the best price, sub-second streaming data, and advanced order types (limit with time-in-force, stop loss, take profit). REST and WebSocket API with the aggregation already done. Seed led by a16z crypto; covered by Fortune, Bloomberg, and CNBC.
 
 ## 🔔 Alerts
 


### PR DESCRIPTION
Adding **[Kairos](https://kairos.trade)** to **🔹 Aggregator**, alongside Verso, Matchr, and TradeFox. Kairos is the cross-venue trading terminal in this category: one merged order ladder across Kalshi, Polymarket, and Predict.fun, with orders routed to whichever venue is showing the best price.

What it does:

- Merges every venue's order book into a single ladder and quotes a composite NBBO; the NBBO endpoint routes the order to the venue actually showing that price.
- Sub-second streaming data over one socket, colocated ingest, execution round trip measured in tens of milliseconds end to end.
- Order types: market and limit with time-in-force, stop loss, take profit, max slippage and retry controls on every order.
- Free to use; traders pay venue fees only, no platform fee.
- REST and WebSocket API exposing the same aggregated data and execution the terminal runs on.

Links:

- **Website:** https://kairos.trade
- **App:** https://app.kairos.trade
- **API docs:** https://docs.kairos.trade
- **X:** https://x.com/kairostradex
- **Discord:** https://discord.gg/kairoslive

Coverage and backing:

- a16z crypto led the $2.5M seed (Feb 2026), with Geneva Trading and the University of Illinois participating: [Fortune](https://fortune.com/2026/02/03/kairos-which-is-building-a-cross-platform-tool-for-prediction-markets-traders-raises-2-5-million-from-a16z-crypto/), [a16z crypto: Investing in Kairos](https://a16zcrypto.com/posts/article/investing-in-kairos/)
- [Bloomberg, Dec 2025: Young founders rush into prediction market startups](https://www.bloomberg.com/news/articles/2025-12-03/young-founders-rush-into-prediction-market-startups)
- [CNBC, Aug 2026: How traders gain an edge on prediction markets](https://www.cnbc.com/2026/08/01/traders-go-full-time-on-prediction-markets-using-ai-bots-and-antennas.html)

Entry follows the section's existing `- [name](url?utm_source=polymark.et) — desc` format. Disclosure: submitted on behalf of the Kairos team.
