### PR TITLE
Add Convex Lake to APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Oddpool aggregates cross-venue prediction market data across platforms like Poly
 - [Marketlens](https://marketlens.trade/) — Data platform providing tick-level historical Polymarket order book and trade data through a Python SDK and backtesting REST API for quantitative research and strategy development.
 - [PolyRouter](https://polyrouter.io?utm_source=polymark.et) — Unified API service that provides normalized prediction market data from Kalshi, Polymarket, Limitless, and other platforms through a single API key and standardized interface.
 - [PMXT](https://github.com/qoery-com/pmxt) - An open-source API for accessing prediction market data across multiple exchanges.
+- [Convex Lake](https://convexlake.com) — Unified API for prediction market and crypto derivatives data: Kalshi, Polymarket, Predict.fun, and Limitless alongside Deribit and Binance options, batch and real-time. Free academic-research tier on request.
 - [pykalshi](https://github.com/ArshKA/kalshi-client) — Feature-rich Python client for Kalshi prediction markets with WebSocket streaming, automatic retries, rate limiting, pandas integration, Jupyter rendering, and local orderbook management.
 
 ## 🔹 Aggregator


### PR DESCRIPTION
Adds Convex Lake (https://convexlake.com) to the APIs section. Unified API for prediction market and crypto derivatives data — Kalshi, Polymarket, Predict.fun, and Limitless alongside Deribit and Binance options, batch and real-time, one schema. Free academic-research tier on request.

Added next to PMXT and Dome, the other multi-platform prediction-market APIs already listed here.